### PR TITLE
JsParser parse_var returns Array instead of Object

### DIFF
--- a/lib/docsparser.js
+++ b/lib/docsparser.js
@@ -439,10 +439,7 @@ JsParser.prototype.parse_var = function(line) {
         return null;
     }
     // variable name, variable value
-    return {
-        name: matches.name,
-        val: matches.val.trim()
-    };
+    return [matches.name, matches.val.trim()];
 };
 
 JsParser.prototype.guess_type_from_value = function(val) {


### PR DESCRIPTION
Method JsParser.prototype.parse_var returns Object, when all other methods return Array.

It causes an exception when comment single variable declaration.

![screenshot 2014-08-01 01 38 27](https://cloud.githubusercontent.com/assets/72428/3776688/9d936bfc-1958-11e4-8669-a093de8101a9.png)
