### PR TITLE
Fix typo in setting name for auto_add_method_tag

### DIFF
--- a/lib/docsparser.js
+++ b/lib/docsparser.js
@@ -120,7 +120,7 @@ DocsParser.prototype.format_function = function(name, args, retval, options) {
     var description = this.get_name_override() || ('['+ escape(name) + (name ? ' ': '') + 'description]');
     out.push('${1:' + description + '}');
 
-    if (this.editor_settings.autoadd_method_tag) {
+    if (this.editor_settings.auto_add_method_tag) {
         out.push('@method '+ escape(name));
     }
 


### PR DESCRIPTION
This was really bugging me. Fixes issue 22.

Thanks for porting this plugin to atom.
