### PR TITLE
Use lowercase "boolean" and "bool" when configured

### DIFF
--- a/lib/docsparser.js
+++ b/lib/docsparser.js
@@ -465,7 +465,7 @@ JsParser.prototype.guess_type_from_value = function(val) {
         return 'Object';
     }
     if((val == 'true') || (val == 'false')) {
-        var ret_val = (short_primitives ? 'Bool' : 'Boolean');
+        var ret_val = (short_primitives ? 'bool' : 'boolean');
         return (lower_primitives ? ret_val : capitalize(ret_val));
     }
     var regex = new RegExp('RegExp\\b|\\\/[^\\/]');


### PR DESCRIPTION
Currently boolean is the only type that always gets capitalized no matter what the settings are.