### PR TITLE
Update docblockr-worker.js

### DIFF
--- a/lib/docblockr-worker.js
+++ b/lib/docblockr-worker.js
@@ -9,7 +9,7 @@ module.exports =
 
     function DocBlockrAtom() {
       var self = this;
-      var settings = atom.config.getSettings().docblockr;
+      var settings = atom.config.get().docblockr;
       this.editor_settings = settings;
 
       atom.config.observe('docblockr', function() {
@@ -153,7 +153,7 @@ module.exports =
     }
 
     DocBlockrAtom.prototype.update_config = function() {
-      var settings = atom.config.getSettings().docblockr;
+      var settings = atom.config.get().docblockr;
       this.editor_settings = settings;
     };
 


### PR DESCRIPTION
Replaced atom.config.getSettings with atom.config.get. getSettings is depricated.