### PR TITLE
Use a config schema instead of configDefaults.

### DIFF
--- a/lib/docblockr.js
+++ b/lib/docblockr.js
@@ -1,29 +1,92 @@
 var DocblockrWorker = require ('./docblockr-worker.js');
 
 module.exports = {
-    configDefaults: {
-        deep_indent: true,
-        extend_double_slash: true,
-        indentation_spaces: 1,
-        indentation_spaces_same_para: 1,
-        // 'no', 'shallow', 'deep'
-        align_tags: 'deep',
-        extra_tags: [],
-        extra_tags_go_after: false,
-        notation_map: [],
-        return_tag: '@return',
-        return_description: true,
-        param_description: true,
-        spacer_between_sections: false,
-        per_section_indent: false,
-        min_spaces_between_columns: 1,
-        auto_add_method_tag: false,
-        simple_mode: false,
-        lower_case_primitives: false,
-        short_primitives: false,
-        override_js_var: false,
-        newline_after_block: false,
-        development_mode: false
+    config: {
+        deep_indent: {
+            type: 'boolean',
+            default: false
+        },
+        extend_double_slash: {
+            type: 'boolean',
+            default: true
+        },
+        indentation_spaces: {
+            type: 'number',
+            default: 1
+        },
+        indentation_spaces_same_para: {
+            type: 'number',
+            default: 1
+        },
+        align_tags: {
+            type: 'string',
+            default: 'deep',
+            enum: ['no', 'shallow', 'deep']
+        },
+        extra_tags: {
+            type: 'array',
+            default: []
+        },
+        extra_tags_go_after: {
+            type: 'boolean',
+            default: false
+        },
+        notation_map: {
+            type: 'array',
+            default: []
+        },
+        return_tag: {
+            type: 'string',
+            default: '@return'
+        },
+        return_description: {
+            type: 'boolean',
+            default: true
+        },
+        param_description: {
+            type: 'boolean',
+            default: true
+        },
+        spacer_between_sections: {
+            type: 'boolean',
+            default: false
+        },
+        per_section_indent: {
+            type: 'boolean',
+            default: false
+        },
+        min_spaces_between_columns: {
+            type: 'number',
+            default: 1
+        },
+        auto_add_method_tag: {
+            type: 'boolean',
+            default: false
+        },
+        simple_mode: {
+            type: 'boolean',
+            default: false
+        },
+        lower_case_primitives: {
+            type: 'boolean',
+            default: false
+        },
+        short_primitives: {
+            type: 'boolean',
+            default: false
+        },
+        override_js_var: {
+            type: 'boolean',
+            default: false
+        },
+        newline_after_block: {
+            type: 'boolean',
+            default: false
+        },
+        development_mode: {
+            type: 'boolean',
+            default: false
+        }
     },
     
     activate: function() {


### PR DESCRIPTION
Kills a Deprecation Cop warning.

configDefaults has been deprecated since v0.133.0: https://github.com/atom/atom/commit/f57dbfd9f531c847f8e1ce34beab2b526f71