### PR TITLE
Use Workspace::getActiveTextEditor()

### DIFF
--- a/lib/docblockr-worker.js
+++ b/lib/docblockr-worker.js
@@ -75,20 +75,20 @@ module.exports =
         }
         else if(self.validate_request({preceding:true, preceding_regex:regex.snippet_1[0], following:true, following_regex:regex.snippet_1[1]})) {
           // console.log('Snippet-1 command');
-          var editor = atom.workspace.getActiveEditor();
+          var editor = atom.workspace.getActiveTextEditor();
           self.write(editor, '\n$0\n ');
         }
         // Close block comment
         else if(self.validate_request({preceding:true, preceding_regex:regex.close_block})) {
           // console.log('Snippet close block comment command');
-          var editor = atom.workspace.getActiveEditor();
+          var editor = atom.workspace.getActiveTextEditor();
           self.write(editor, '\n$0\n */');
         }
         // extend line comments (// and #)
         else if((self.editor_settings.extend_double_slash == true) && (self.validate_request({preceding:true, preceding_regex:regex.extend_line, scope:'comment.line'}))) {
           // console.log('Snippet Extend line command');
           var _regex = /^(\s*(?:#|\/\/[\/!]?)\s*).*$/;
-          var editor = atom.workspace.getActiveEditor();
+          var editor = atom.workspace.getActiveTextEditor();
           var cursor_position = editor.getCursorBufferPosition();
           var line_text = editor.lineForBufferRow(cursor_position.row);
           line_text = line_text.replace(_regex, '$1');
@@ -98,7 +98,7 @@ module.exports =
         else if(self.validate_request({preceding:true, preceding_regex:regex.extend, scope:'comment.block'})) {
           // console.log('Snippet Extend command');
           var _regex = /^(\s*\*\s*).*$/;
-          var editor = atom.workspace.getActiveEditor();
+          var editor = atom.workspace.getActiveTextEditor();
           var cursor_position = editor.getCursorBufferPosition();
           var line_text = editor.lineForBufferRow(cursor_position.row);
           line_text = line_text.replace(_regex, '$1');
@@ -115,7 +115,7 @@ module.exports =
         if(self.validate_request({preceding:true, preceding_regex:_regex}))
           self.parse_command(true);
         else {
-          var editor = atom.workspace.getActiveEditor();
+          var editor = atom.workspace.getActiveTextEditor();
           editor.insertNewline();
           //event.abortKeyBinding();
         }
@@ -251,7 +251,7 @@ module.exports =
     };
 
     DocBlockrAtom.prototype.parse_command = function(inline) {
-      var editor = atom.workspace.getActiveEditor();
+      var editor = atom.workspace.getActiveTextEditor();
       if (typeof editor === 'undefined' || editor === null) {
         return;
       }
@@ -278,7 +278,7 @@ module.exports =
       /**
        * Trim the automatic whitespace added when creating a new line in a docblock.
        */
-      var editor = atom.workspace.getActiveEditor();
+      var editor = atom.workspace.getActiveTextEditor();
       if (typeof editor === 'undefined' || editor === null) {
         return;
       }
@@ -294,7 +294,7 @@ module.exports =
     };
 
     DocBlockrAtom.prototype.indent_command = function() {
-      var editor = atom.workspace.getActiveEditor();
+      var editor = atom.workspace.getActiveTextEditor();
       var current_pos = editor.getCursorBufferPosition();
       var prev_line = editor.lineForBufferRow(current_pos.row - 1);
       var spaces = this.get_indent_spaces(editor, prev_line);
@@ -314,7 +314,7 @@ module.exports =
     };
 
     DocBlockrAtom.prototype.join_command = function() {
-      var editor = atom.workspace.getActiveEditor();
+      var editor = atom.workspace.getActiveTextEditor();
       var selections = editor.getSelections();
       var i, j, len, row_begin;
       var text_with_ending = function(row) {
@@ -349,7 +349,7 @@ module.exports =
     };
 
     DocBlockrAtom.prototype.decorate_command = function() {
-      var editor = atom.workspace.getActiveEditor();
+      var editor = atom.workspace.getActiveTextEditor();
       var pos = editor.getCursorBufferPosition();
       var whitespace_re = /^(\s*)\/\//;
       var scope_range = this.scope_range(editor, pos, 'comment.line.double-slash');
@@ -388,7 +388,7 @@ module.exports =
     };
 
     DocBlockrAtom.prototype.decorate_multiline_command = function() {
-      var editor = atom.workspace.getActiveEditor();
+      var editor = atom.workspace.getActiveTextEditor();
       var pos = editor.getCursorBufferPosition();
       var whitespace_re = /^(\s*)\/\*/;
       var tab_size = atom.config.get('editor.tabLength');
@@ -463,7 +463,7 @@ module.exports =
        *//*|   <-- from here
       |      <-- to here
        */
-      var editor = atom.workspace.getActiveEditor();
+      var editor = atom.workspace.getActiveTextEditor();
       var cursor = editor.getCursorBufferPosition();
       var text = editor.lineForBufferRow(cursor.row);
       text = text.replace(/^(\s*)\s\*\/.*/, '\n$1');
@@ -476,7 +476,7 @@ module.exports =
       var tab_stop = function(m, g1) {
         return util.format('${%d:%s}', tab_index(), g1);
       };
-      var editor = atom.workspace.getActiveEditor();
+      var editor = atom.workspace.getActiveTextEditor();
       var pos = editor.getCursorBufferPosition();
       var Snippets = atom.packages.activePackages.snippets.mainModule;
       // disable all snippet expansions
@@ -505,7 +505,7 @@ module.exports =
        *  Wrap column is set by the first ruler (set in Default.sublime-settings), or 80 by default.
        * Shortcut Key: alt+q
        */
-      var editor = atom.workspace.getActiveEditor();
+      var editor = atom.workspace.getActiveTextEditor();
       var pos = editor.getCursorBufferPosition();
       var tab_size = atom.config.get('editor.tabLength');
       var wrap_len = atom.config.get('editor.preferredLineLength');

--- a/lib/docblockr-worker.js
+++ b/lib/docblockr-worker.js
@@ -182,7 +182,7 @@ module.exports =
       var following_regex = (typeof options.following_regex !== 'undefined') ? options.following_regex : '';
       var scope     = (typeof options.scope !== 'undefined') ? options.scope : false;
 
-      var editor = atom.workspace.getActiveEditor();
+      var editor = atom.workspace.getActiveTextEditor();
       this.cursors = [];
       var cursor, i, len, following_text, preceding_text;
 


### PR DESCRIPTION
Kills a Deprecation Cop warning.

getActiveEditor has been deprecated since v0.153.0: atom/atom@714cbc9