### PR TITLE
Use editor.lineTextForBufferRow(row)

### DIFF
--- a/lib/docblockr-worker.js
+++ b/lib/docblockr-worker.js
@@ -210,7 +210,7 @@ module.exports =
           preceding_text = editor.getTextInBufferRange([[cursor_position.row, 0], cursor_position]);
 
         if(following) {
-          var line_length = editor.lineLengthForBufferRow(cursor_position.row);
+          var line_length = editor.lineTextForBufferRow(cursor_position.row).length;
           var following_range = [cursor_position, [cursor_position.row, line_length]];
           following_text = editor.getTextInBufferRange(following_range);
         }

--- a/lib/docblockr-worker.js
+++ b/lib/docblockr-worker.js
@@ -284,7 +284,7 @@ module.exports =
       }
       var cursor_position = editor.getCursorBufferPosition();
       var line_text = editor.lineTextForBufferRow(cursor_position.row);
-      var line_length = editor.lineLengthForBufferRow(cursor_position.row);
+      var line_length = editor.lineTextForBufferRow(cursor_position.row).length;
       var spaces = Math.max(0, this.editor_settings.indentation_spaces);
 
       var regex = /^(\s*\*)\s*$/;
@@ -342,7 +342,7 @@ module.exports =
         }
         var regex = /[ \t]*\n[ \t]*((?:\*|\/\/[!/]?|#)[ \t]*)?/g;
         text = text.replace(regex, ' ');
-        var end_line_length = editor.lineLengthForBufferRow(row_begin + no_rows - 1);
+        var end_line_length = editor.lineTextForBufferRow(row_begin + no_rows - 1).length;
         var range = [[row_begin, 0], [row_begin + no_rows - 1, end_line_length]];
         editor.setTextInBufferRange(range, text);
       }
@@ -370,7 +370,7 @@ module.exports =
           leading_ws = matches[1].length;
 
         leading_ws-= tab_count;
-        max_len = Math.max(max_len, editor.lineLengthForBufferRow(_row + _i));
+        max_len = Math.max(max_len, editor.lineTextForBufferRow(_row + _i).length);
       }
 
       var line_length = max_len - leading_ws;
@@ -379,7 +379,7 @@ module.exports =
 
       for(_i = _len; _i >= 0; _i--) {
         line_text = editor.lineTextForBufferRow(_row + _i);
-        var _length = editor.lineLengthForBufferRow(_row + _i);
+        var _length = editor.lineTextForBufferRow(_row + _i).length;
         var r_padding = 1 + (max_len - _length);
         var _range = [[scope_range[0].row + _i, 0], [scope_range[0].row + _i, _length]];
         editor.setTextInBufferRange(_range, leading_ws + line_text + this.repeat(' ', r_padding) + '//');
@@ -448,7 +448,7 @@ module.exports =
       // skip first line and last line
       for(_i = _len-1; _i > 0; _i--) {
         line_text = editor.lineTextForBufferRow(_row + _i);
-        var _length = editor.lineLengthForBufferRow(_row + _i);
+        var _length = editor.lineTextForBufferRow(_row + _i).length;
         var r_padding = 1 + (max_len - line_lengths[_i]);
         _range = [[scope_range[0].row + _i, 0], [scope_range[0].row + _i, _length]];
         editor.setTextInBufferRange(_range, line_text + this.repeat(' ', r_padding) + '*');
@@ -677,7 +677,7 @@ module.exports =
       inline = (typeof inline === 'undefined') ? false : inline;
       var cursor_position = editor.getCursorBufferPosition(); // will handle only one instance
       // Get trailing string
-      var line_length = editor.lineLengthForBufferRow(cursor_position.row);
+      var line_length = editor.lineTextForBufferRow(cursor_position.row).length;
       this.trailing_range = [cursor_position, [cursor_position.row, line_length]];
       this.trailing_string = editor.getTextInBufferRange(this.trailing_range);
       // drop trailing */
@@ -757,7 +757,7 @@ module.exports =
       start = _range.start;
       end = _range.end;
       while(_row >= 0) {
-        line_length = editor.lineLengthForBufferRow(_row);
+        line_length = editor.lineTextForBufferRow(_row).length;
         _range = editor.displayBuffer.bufferRangeForScopeAtPosition(scope_name, [_row, line_length]);
         if(_range == null)
           break;
@@ -770,7 +770,7 @@ module.exports =
       _row = point.row;
       var last_row = editor.getLastBufferRow();
       while(_row <= last_row) {
-        line_length = editor.lineLengthForBufferRow(_row);
+        line_length = editor.lineTextForBufferRow(_row).length;
         _range = editor.displayBuffer.bufferRangeForScopeAtPosition(scope_name, [_row, 0]);
         if(_range == null)
           break;

--- a/lib/docblockr-worker.js
+++ b/lib/docblockr-worker.js
@@ -90,7 +90,7 @@ module.exports =
           var _regex = /^(\s*(?:#|\/\/[\/!]?)\s*).*$/;
           var editor = atom.workspace.getActiveEditor();
           var cursor_position = editor.getCursorBufferPosition();
-          var line_text = editor.lineForBufferRow(cursor_position.row);
+          var line_text = editor.lineTextForBufferRow(cursor_position.row);
           line_text = line_text.replace(_regex, '$1');
           editor.insertText('\n' + line_text);
         }
@@ -100,7 +100,7 @@ module.exports =
           var _regex = /^(\s*\*\s*).*$/;
           var editor = atom.workspace.getActiveEditor();
           var cursor_position = editor.getCursorBufferPosition();
-          var line_text = editor.lineForBufferRow(cursor_position.row);
+          var line_text = editor.lineTextForBufferRow(cursor_position.row);
           line_text = line_text.replace(_regex, '$1');
           editor.insertText('\n' + line_text);
         }
@@ -283,7 +283,7 @@ module.exports =
         return;
       }
       var cursor_position = editor.getCursorBufferPosition();
-      var line_text = editor.lineForBufferRow(cursor_position.row);
+      var line_text = editor.lineTextForBufferRow(cursor_position.row);
       var line_length = editor.lineLengthForBufferRow(cursor_position.row);
       var spaces = Math.max(0, this.editor_settings.indentation_spaces);
 
@@ -296,7 +296,7 @@ module.exports =
     DocBlockrAtom.prototype.indent_command = function() {
       var editor = atom.workspace.getActiveEditor();
       var current_pos = editor.getCursorBufferPosition();
-      var prev_line = editor.lineForBufferRow(current_pos.row - 1);
+      var prev_line = editor.lineTextForBufferRow(current_pos.row - 1);
       var spaces = this.get_indent_spaces(editor, prev_line);
 
       if(spaces !== null) {
@@ -360,7 +360,7 @@ module.exports =
       _len = Math.abs(scope_range[0].row - scope_range[1].row);
 
       for(_i = 0; _i <= _len; _i++) {
-        line_text = editor.lineForBufferRow(_row + _i);
+        line_text = editor.lineTextForBufferRow(_row + _i);
         tab_count = line_text.split('\t').length - 1;
 
         var matches = whitespace_re.exec(line_text);
@@ -378,7 +378,7 @@ module.exports =
       editor.buffer.insert(scope_range[1], '\n' + leading_ws + this.repeat('/' , (line_length + 3)) + '\n');
 
       for(_i = _len; _i >= 0; _i--) {
-        line_text = editor.lineForBufferRow(_row + _i);
+        line_text = editor.lineTextForBufferRow(_row + _i);
         var _length = editor.lineLengthForBufferRow(_row + _i);
         var r_padding = 1 + (max_len - _length);
         var _range = [[scope_range[0].row + _i, 0], [scope_range[0].row + _i, _length]];
@@ -401,7 +401,7 @@ module.exports =
       _len = Math.abs(scope_range[0].row - scope_range[1].row);
 
       // get block indent from first line
-      line_text = editor.lineForBufferRow(_row);
+      line_text = editor.lineTextForBufferRow(_row);
       block_tab_count = line_text.split('\t').length - 1;
       matches = whitespace_re.exec(line_text);
       if(matches == null)
@@ -413,7 +413,7 @@ module.exports =
       // get max_len
       for(_i = 1; _i < _len; _i++) {
         var text_length;
-        line_text = editor.lineForBufferRow(_row + _i);
+        line_text = editor.lineTextForBufferRow(_row + _i);
         text_length = line_text.length;
         content_tab_count = line_text.split('\t').length - 1;
         line_lengths[_i] = text_length - content_tab_count + (content_tab_count * tab_size);
@@ -424,7 +424,7 @@ module.exports =
       block_ws = this.repeat('\t', block_tab_count) + this.repeat(' ', block_ws);
 
       // last line
-      line_text = editor.lineForBufferRow(scope_range[1].row);
+      line_text = editor.lineTextForBufferRow(scope_range[1].row);
       line_text = line_text.replace(/^(\s*)(\*)+\//, function(self) {
         return function(match, p1, stars) {
           var len = stars.length;
@@ -435,7 +435,7 @@ module.exports =
       editor.setTextInBufferRange(_range, line_text);
 
       // first line
-      line_text = editor.lineForBufferRow(scope_range[0].row);
+      line_text = editor.lineTextForBufferRow(scope_range[0].row);
       line_text = line_text.replace(/^(\s*)\/(\*)+/, function(self) {
         return function(match, p1, stars) {
           var len = stars.length;
@@ -447,7 +447,7 @@ module.exports =
 
       // skip first line and last line
       for(_i = _len-1; _i > 0; _i--) {
-        line_text = editor.lineForBufferRow(_row + _i);
+        line_text = editor.lineTextForBufferRow(_row + _i);
         var _length = editor.lineLengthForBufferRow(_row + _i);
         var r_padding = 1 + (max_len - line_lengths[_i]);
         _range = [[scope_range[0].row + _i, 0], [scope_range[0].row + _i, _length]];
@@ -465,7 +465,7 @@ module.exports =
        */
       var editor = atom.workspace.getActiveEditor();
       var cursor = editor.getCursorBufferPosition();
-      var text = editor.lineForBufferRow(cursor.row);
+      var text = editor.lineTextForBufferRow(cursor.row);
       text = text.replace(/^(\s*)\s\*\/.*/, '\n$1');
       editor.insertText(text, options={ autoIndentNewline:false });
     };
@@ -526,7 +526,7 @@ module.exports =
       var start_row = scope_range[0].row;
       len = Math.abs(scope_range[0].row - scope_range[1].row);
       for(i = 0; i <= len; i++) {
-        _text = editor.lineForBufferRow(start_row + i);
+        _text = editor.lineTextForBufferRow(start_row + i);
         _col = _text.search(/^\s*\* /);
         if(_col > -1) {
           if(i === 0) {
@@ -541,7 +541,7 @@ module.exports =
       }
       // find the first tag, or the end of the comment
       for(i = 0; i <= len; i++) {
-        _text = editor.lineForBufferRow(start_row + i);
+        _text = editor.lineTextForBufferRow(start_row + i);
         _col = _text.search(/^\s*\*(\/)/);
         if(_col > -1) {
           if(i === 0) {
@@ -740,7 +740,7 @@ module.exports =
         // TODO: no longer works
         if(point >= editor.getText().length)
             return;
-        return editor.lineForBufferRow(point.row);
+        return editor.lineTextForBufferRow(point.row);
     };
 
     DocBlockrAtom.prototype.scope_range = function(editor, point, scope_name) {


### PR DESCRIPTION
Kills a Deprecation Cop warning.

lineLengthForBufferRow has been deprecated since v0.125.0: atom/atom@5e21d1c
lineForBufferRow has been deprecated since v0.125.0: atom/atom@b516f5a