### PR TITLE
Use editor.scopeDescriptorForBufferPosition.

### DIFF
--- a/lib/docblockr-worker.js
+++ b/lib/docblockr-worker.js
@@ -192,7 +192,7 @@ module.exports =
         var cursor_position = cursor_positions[i].getBufferPosition();
 
         if(scope) {
-          var scope_list = editor.scopesForBufferPosition(cursor_position);
+          var scope_list = editor.scopeDescriptorForBufferPosition(cursor_position).getScopesArray();
           var _i, _len;
           for(_i = 0; _len = scope_list.length, _i < _len; _i++) {
             if(scope_list[_i].search(scope) > -1) {


### PR DESCRIPTION
Kills a Deprecation Cop warning.

editor.scopesForBufferPosition has been deprecated since v0.139.0: atom/atom@137eeab