### PR TITLE
Allow @return statements for function names containing (but not start…

### DIFF
--- a/lib/docsparser.js
+++ b/lib/docsparser.js
@@ -201,7 +201,7 @@ DocsParser.prototype.format_function = function(name, args, retval, options) {
 
 DocsParser.prototype.get_function_return_type = function(name, retval) {
     // returns None for no return type. False meaning unknown, or a string
-    if(name.search(/[A-Z]/) > -1)
+    if(/^[A-Z]/.test(name))
         return null;  // no return, but should add a class
 
     if(name.search(/[$_]?(?:set|add)($|[A-Z_])/) > -1)


### PR DESCRIPTION
…ing with) caps.

Fixes NikhilKalige/docblockr#17.