### PR TITLE
grammar scope name for cpp is 'cpp' (at least on new atom versions)

### DIFF
--- a/lib/docblockr-worker.js
+++ b/lib/docblockr-worker.js
@@ -810,7 +810,7 @@ module.exports =
           return new Parsers.CoffeeParser(settings);
       else if((source_lang === "actionscript") || (source_lang == 'haxe'))
           return new Parsers.ActionscriptParser(settings);
-      else if((source_lang === "c++") || (source_lang === 'c') || (source_lang === 'cuda-c++'))
+      else if((source_lang === "c++") || (source_lang === "cpp") || (source_lang === 'c') || (source_lang === 'cuda-c++'))
           return new Parsers.CppParser(settings);
       else if((source_lang === 'objc') || (source_lang === 'objc++'))
           return new Parsers.ObjCParser(settings);


### PR DESCRIPTION
this fixes the issue i previously reported yesterday!