### PR TITLE
Fixed the issue #131 that adds an asterisk when starting a new line from the end of block comments.

### DIFF
--- a/lib/docblockr-worker.js
+++ b/lib/docblockr-worker.js
@@ -66,7 +66,7 @@ module.exports =
           // extend line
           'extend_line': /^\s*(\/\/[\/!]?|#)/,
           // Extend docblock by adding an asterix at start
-          'extend': /^\s*\*/,
+          'extend': /^\s*\*[^\/]*$/,
         };
 
         // Parse Command


### PR DESCRIPTION
Fixed the issue that one more asterisk is added when starting a new line from a block comments.

Solution:
I modified the regular expression for the case that an asterisk needs to be added. The new expression will check that if a string is ended by an slash(/), a new asterisk will be added only when the string is not ended by an slash(/).

Example:
In this case:

```
/**********
 * asides *
 **********/ <-- enter here, it will create a new line without asterisk
```

In the cases below they still work:

```
/*
 * <-- enter here, it will create a new line with an asterisk
 *
 * foo bar  <-- enter here, it will also create a new line with an asterisk
 */
```
