### PR TITLE
fix function not parse bug

### DIFF
--- a/lib/docsparser.js
+++ b/lib/docsparser.js
@@ -321,6 +321,7 @@ DocsParser.prototype.get_definition = function(editor, pos, read_line) {
     var maxLines = 25;  //# don't go further than this
     var openBrackets = 0;
     var definition = '';
+    var hasFindedBrackets = false;
 
     // make pos writable
     //pos = pos.copy();
@@ -366,11 +367,12 @@ DocsParser.prototype.get_definition = function(editor, pos, read_line) {
         var match;
         while((match = regex.exec(searchForBrackets)) !== null) {
             Brackets.push(match);
+            hasFindedBrackets = true;
         }
         openBrackets = Brackets.reduce(count_brackets, openBrackets);
 
         definition += line;
-        if(openBrackets === 0)
+        if(openBrackets === 0 && hasFindedBrackets)
             break;
     }
     return definition;


### PR DESCRIPTION
fix function not parse bug, when add comment position has a new line between the definition of the function.

now we can do this:

``` C
/**
 * [sfvfs_openfs description]
 * @method sfvfs_openfs
 * @param  filename     [description]
 * @param  options      [description]
 * @return              [description]
 */

extern struct sfvfs_fs*
sfvfs_openfs(const char* filename, struct sfvfs_options* options);

```
