### PR TITLE
Some fixes to write TypeDoc for typescript

### DIFF
--- a/lib/docblockr.js
+++ b/lib/docblockr.js
@@ -67,6 +67,10 @@ module.exports = {
             type: 'boolean',
             default: false
         },
+        enable_type_in_param: {
+          type: 'boolean',
+          default: true
+        },
         lower_case_primitives: {
             type: 'boolean',
             default: false
@@ -88,7 +92,7 @@ module.exports = {
             default: false
         }
     },
-    
+
     activate: function() {
         return (this.Docblockr = new DocblockrWorker());
     }

--- a/lib/docblockr.js
+++ b/lib/docblockr.js
@@ -67,10 +67,6 @@ module.exports = {
             type: 'boolean',
             default: false
         },
-        enable_type_in_param: {
-          type: 'boolean',
-          default: true
-        },
         lower_case_primitives: {
             type: 'boolean',
             default: false

--- a/lib/docsparser.js
+++ b/lib/docsparser.js
@@ -133,7 +133,7 @@ DocsParser.prototype.format_function = function(name, args, retval, options) {
             var arg_name = parsed_args[i][1];
 
 
-            if (this.editor_settings.enable_type_in_param) {
+            if (this.settings.typeInfo) {
               type_info = this.get_type_info(arg_type, arg_name);
               format_str = '@param %s%s';
             } else {
@@ -145,7 +145,7 @@ DocsParser.prototype.format_function = function(name, args, retval, options) {
                 format_str += ' ${1:[description]}';
             //out.push(str);
 
-            if (this.editor_settings.enable_type_in_param) {
+            if (this.settings.typeInfo) {
               out.push(util.format(format_str, type_info, escape(arg_name)));
             } else {
               out.push(util.format(format_str, escape(arg_name)));

--- a/lib/docsparser.js
+++ b/lib/docsparser.js
@@ -132,14 +132,24 @@ DocsParser.prototype.format_function = function(name, args, retval, options) {
             var arg_type = parsed_args[i][0];
             var arg_name = parsed_args[i][1];
 
-            type_info = this.get_type_info(arg_type, arg_name);
-            format_str = '@param %s%s';
+
+            if (this.editor_settings.enable_type_in_param) {
+              type_info = this.get_type_info(arg_type, arg_name);
+              format_str = '@param %s%s';
+            } else {
+              format_str = '@param %s';
+            }
             //var str = '@param ' + type_info + escape(arg_name);
             if(this.editor_settings.param_description)
                 //str+= ' ${1:[description]}';
                 format_str += ' ${1:[description]}';
             //out.push(str);
-            out.push(util.format(format_str, type_info, escape(arg_name)));
+
+            if (this.editor_settings.enable_type_in_param) {
+              out.push(util.format(format_str, type_info, escape(arg_name)));
+            } else {
+              out.push(util.format(format_str, escape(arg_name)));
+            }
         }
     }
 

--- a/lib/docsparser.js
+++ b/lib/docsparser.js
@@ -193,7 +193,9 @@ DocsParser.prototype.format_function = function(name, args, retval, options) {
         format_args.forEach(function(element) {
             format_str = util.format(format_str, element);
         });
-        out.push(format_str);
+        if(name !== 'constructor') {
+          out.push(format_str);
+        }
     }
     var matching_names = this.get_matching_notations(name);
     for (i = 0; len = matching_names.length,i < len; i++) {

--- a/lib/docsparser.js
+++ b/lib/docsparser.js
@@ -77,9 +77,12 @@ DocsParser.prototype.format_var = function(name, val, valType) {
     else {
         temp = util.format('${1:[%s description]}', escape(name));
         out.push(temp);
-        temp = util.format('@%s %s${1:%s}%s',
-                                this.settings.typeTag, brace_open, valType, brace_close);
-        out.push(temp);
+
+        if (this.settings.typeInfo) {
+          temp = util.format('@%s %s${1:%s}%s',
+          this.settings.typeTag, brace_open, valType, brace_close);
+          out.push(temp);
+        }
     }
     return out;
 };

--- a/lib/languages/typescript.js
+++ b/lib/languages/typescript.js
@@ -62,8 +62,13 @@ TypescriptParser.prototype.get_arg_name = function(arg) {
     if(arg.indexOf(':') > -1)
         arg = arg.split(':')[0];
 
+    var argIdentifier = /public\s+|private\s+/g;
+    arg = arg.replace(argIdentifier, '');
+
     var regex = /[ \?]/g;
-    return arg.replace(regex, '');
+    arg = arg.replace(regex, '');
+
+    return arg;
 };
 
 TypescriptParser.prototype.parse_var = function(line) {

--- a/lib/languages/typescript.js
+++ b/lib/languages/typescript.js
@@ -15,7 +15,7 @@ TypescriptParser.prototype.setup_settings = function() {
     this.settings = {
         // curly brackets around the type information
         'curlyTypes': true,
-        'typeInfo': true,
+        'typeInfo': false,
         'typeTag': 'type',
         // technically, they can contain all sorts of unicode, but w/e
         'varIdentifier': identifier,


### PR DESCRIPTION
This pull request fix #134 and some other following problems for typescript.
- function's `@param` doesn't have type
- constructor doesn't have `@return`
- constructor's parameter name doesn't include constructor parameter properties (`public`, `private`)
- var comment doesn't have `@type`
