### PR TITLE
Add an option for auto-adding @property tags to properties of objects.

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,8 @@ You can access the configuration settings by entering `Docblockr` in atom settin
 
 - `autoadd_method_tag` *(Boolean)* Add a `@method` tag to docblocks of functions. Default: `false`
 
+- `autoadd_property_tag` *(Boolean)* Add a `@property` tag to docblocks of object properties. Default: `false`
+
 - `simple_mode` *(Boolean)* If true, DocBlockr won't add a template when creating a doc block before a function or variable. Useful if you don't want to write Javadoc-style, but still want your editor to help when writing block comments. Default: `false`
 
 - `lower_case_primitives` *(Boolean)* If true, primitive data types are added in lower case, eg "number" instead of "Number". Default: `false`

--- a/lib/docblockr.js
+++ b/lib/docblockr.js
@@ -63,6 +63,10 @@ module.exports = {
             type: 'boolean',
             default: false
         },
+        auto_add_property_tag: {
+            type: 'boolean',
+            default: false
+        },
         simple_mode: {
             type: 'boolean',
             default: false
@@ -88,7 +92,7 @@ module.exports = {
             default: false
         }
     },
-    
+
     activate: function() {
         return (this.Docblockr = new DocblockrWorker());
     }

--- a/lib/docsparser.js
+++ b/lib/docsparser.js
@@ -54,6 +54,12 @@ DocsParser.prototype.format_var = function(name, val, valType) {
     valType = typeof valType !== 'undefined' ? valType : null;
     var out = [];
     var brace_open, brace_close, temp;
+    var propertyTag = '';
+
+    if (this.editor_settings.auto_add_property_tag) {
+        propertyTag = '@property '+ escape(name);
+    }
+
     if(this.settings.curlyTypes) {
         brace_open = '{';
         brace_close = '}';
@@ -71,12 +77,17 @@ DocsParser.prototype.format_var = function(name, val, valType) {
     }
     if(this.inline) {
         temp = util.format('@%s %s${1:%s}%s ${1:[description]}',
-                                        this.settings.typeTag, brace_open, valType, brace_close);
+                                        propertyTag, this.settings.typeTag, brace_open, valType, brace_close);
         out.push(temp);
     }
     else {
         temp = util.format('${1:[%s description]}', escape(name));
         out.push(temp);
+
+        if ( propertyTag.length ) {
+          out.push(propertyTag);
+        }
+
         temp = util.format('@%s %s${1:%s}%s',
                                 this.settings.typeTag, brace_open, valType, brace_close);
         out.push(temp);


### PR DESCRIPTION
My team has recently switched over to the YUIDoc format for writing our documentation and found that we needed the ability to automatically add `@property` tags to object properties, much in the same way that `@method` tags can automatically be added to object methods.

This PR adds the necessary configuration option, functional code, and documentation to make this happen. It has been tested both with the configuration turned on and off and it supports both block and inline formats.