### PR TITLE
Add parse_var methode to the RustParser

### DIFF
--- a/lib/languages/rust.js
+++ b/lib/languages/rust.js
@@ -52,4 +52,9 @@ RustParser.prototype.format_function = function(name, args) {
     return [name];
 };
 
+RustParser.prototype.format_var = function(name, val, valType) {
+    return [name];
+};
+
+
 module.exports = RustParser;

--- a/lib/languages/rust.js
+++ b/lib/languages/rust.js
@@ -13,7 +13,7 @@ RustParser.prototype.setup_settings = function() {
         'typeInfo': false,
         'typeTag': false,
         'varIdentifier': '.*',
-        'fnIdentifier':  '.*',
+        'fnIdentifier': '[a-zA-Z_][a-zA-Z_0-9]*',
         'fnOpener': '^\\s*fn',
         'commentCloser': ' */',
         'bool': 'Boolean',
@@ -22,12 +22,16 @@ RustParser.prototype.setup_settings = function() {
 };
 
 RustParser.prototype.parse_function = function(line) {
-    var regex = xregexp('\\s*fn\\s+(?P<name>\\S+)');
+    // TODO: add regexp for closures syntax
+    // TODO: parse params
+    var regex = xregexp('\\s*fn\\s+(?P<name>' + this.settings.fnIdentifier + ')');
+
     var matches = xregexp.exec(line, regex);
-    if(matches === null)
+    if(matches === null || matches.name === undefined) {
         return null;
-    var name = matches.name || '';
-    return [ name, []];
+    }
+    var name = matches.name;
+    return [name, null];
 };
 
 RustParser.prototype.parse_var = function(line) {

--- a/lib/languages/rust.js
+++ b/lib/languages/rust.js
@@ -30,8 +30,12 @@ RustParser.prototype.parse_function = function(line) {
     return [ name, []];
 };
 
+RustParser.prototype.parse_var = function(line) {
+    return null;
+};
+
 RustParser.prototype.format_function = function(name, args) {
-        return name;
+    return name;
 };
 
 module.exports = RustParser;

--- a/lib/languages/rust.js
+++ b/lib/languages/rust.js
@@ -26,7 +26,7 @@ RustParser.prototype.parse_function = function(line) {
     var matches = xregexp.exec(line, regex);
     if(matches === null)
         return null;
-    var name = [].join(matches.name);
+    var name = matches.name || '';
     return [ name, []];
 };
 

--- a/lib/languages/rust.js
+++ b/lib/languages/rust.js
@@ -49,7 +49,7 @@ RustParser.prototype.parse_var = function(line) {
 };
 
 RustParser.prototype.format_function = function(name, args) {
-    return name;
+    return [name];
 };
 
 module.exports = RustParser;

--- a/lib/languages/rust.js
+++ b/lib/languages/rust.js
@@ -12,7 +12,7 @@ RustParser.prototype.setup_settings = function() {
         'curlyTypes': false,
         'typeInfo': false,
         'typeTag': false,
-        'varIdentifier': '.*',
+        'varIdentifier': '[a-zA-Z_][a-zA-Z_0-9]*',
         'fnIdentifier': '[a-zA-Z_][a-zA-Z_0-9]*',
         'fnOpener': '^\\s*fn',
         'commentCloser': ' */',
@@ -35,7 +35,17 @@ RustParser.prototype.parse_function = function(line) {
 };
 
 RustParser.prototype.parse_var = function(line) {
-    return null;
+    // TODO: add support for struct and tuple destructuring
+    // TODO: parse type and value
+    var regex = xregexp('\\s*let\\s+(mut\\s+)?(?P<name>' + this.settings.varIdentifier + ')');
+
+    var matches = xregexp.exec(line, regex);
+    if(matches === null || matches.name === undefined) {
+        return null;
+    }
+
+    var name = matches.name;
+    return [name, null, null];
 };
 
 RustParser.prototype.format_function = function(name, args) {

--- a/lib/languages/rust.js
+++ b/lib/languages/rust.js
@@ -16,8 +16,8 @@ RustParser.prototype.setup_settings = function() {
         'fnIdentifier': '[a-zA-Z_][a-zA-Z_0-9]*',
         'fnOpener': '^\\s*fn',
         'commentCloser': ' */',
-        'bool': 'Boolean',
-        'function': 'Function'
+        'bool': 'bool',
+        'function': 'fn'
     };
 };
 

--- a/spec/dataset/rust.yaml
+++ b/spec/dataset/rust.yaml
@@ -1,0 +1,74 @@
+name: RustParser
+
+parse_function:
+    -
+        - should parse simple function
+        - fn main() {}
+        - ['main', null]
+    -
+        - should parse function with return type
+        - fn foo() -> i32 {
+        - ['foo', null]
+    -
+        - should parse function with params
+        - 'fn bar(x: i32, y: &str) {'
+        - ['bar', null]
+    -
+        - should parse function with params and return type
+        - 'fn baz(x: i32) -> i32 {'
+        - ['baz', null]
+    -
+        - should parse function with mutable reference as param
+        - 'fn add_one(x: &mut i32) -> i32 {'
+        - ['add_one', null]
+    -
+        - should parse function with complex return type
+        - 'fn do_something(y: &mut u64) -> (i32, &str) {'
+        - ['do_something', null]
+    -
+        - should parse function in uncommon syntax
+        - 'fn foo  ( x  : i32   )  -> i32'
+        - ['foo', null]
+    -
+        - should parse method with normal `self` reference and return type
+        - fn is_foo(&self) -> bool
+        - ['is_foo', null]
+    -
+        - should parse method with mutable `self` reference and extra param
+        - 'fn is_bar(&self, x: &mut Bar)'
+        - ['is_bar', null]
+
+
+parse_var:
+    -
+        - should parse variable declaration
+        - let foo;
+        - ['foo', null, null]
+    -
+        - should parse mutable variable declaration
+        - let mut foo = 0;
+        - ['foo', null, null]
+    -
+        - should parse variable declaration with value
+        - let bar = 0;
+        - ['bar', null, null]
+    -
+        - should parse variable declaration with value and type suffix
+        - let baz = 15.18f64;
+        - ['baz', null, null]
+    -
+        - should parse variable declaration with type
+        - 'let foo: i32;'
+        - ['foo', null, null]
+    -
+        - should parse mutable variable declaration with type
+        - 'let mut foo: i32;'
+        - ['foo', null, null]
+    -
+        - should parse variable declaration with type and value
+        - 'let bar: i32 = 15;'
+        - ['bar', null, null]
+    -
+        - should parse variable declaration with value from function call
+        - let bar = get_some_value();
+        - ['bar', null, null]


### PR DESCRIPTION
This will prevent an error, when using block comments.