### PR TITLE
Make selector for the `docblockr:parse-tab` event more specific

### DIFF
--- a/keymaps/docblockr.json
+++ b/keymaps/docblockr.json
@@ -1,6 +1,8 @@
 {
+    "atom-workspace atom-text-editor:not([mini])": {
+        "tab": "docblockr:parse-tab"
+    },
     "atom-text-editor:not([mini])": {
-        "tab": "docblockr:parse-tab",
         "enter": "docblockr:parse-enter",
         "shift-enter": "docblockr:parse-inline"
     }


### PR DESCRIPTION
This will prevent the `sippets:Expand` Event from overriding this event and fix #167