### PR TITLE
Remove hardcoded tab (`\t`) indentation

### DIFF
--- a/lib/docblockr-worker.js
+++ b/lib/docblockr-worker.js
@@ -315,13 +315,16 @@ module.exports =
         var to_star = matches[1].length;
         var to_insert = spaces - current_pos.column + to_star;
         if(to_insert <= 0) {
-          this.write(editor, '\t');
+          if(self.event) {
+            self.event.abortKeyBinding();
+          }
           return;
         }
         editor.insertText(this.repeat(' ', to_insert));
       }
-      else
-        editor.insertText('\t');
+      else if(self.event) {
+        self.event.abortKeyBinding();
+      }
     };
 
     DocBlockrAtom.prototype.join_command = function() {


### PR DESCRIPTION
When pressing tab inside a comment `DocBlockrAtom.prototype.indent_command` is executed. This will copy the indention of the the line above or just do a normal indentation if the line above is not indented.
The normal indentation shouldn't be just a tab, rather fall back to the default behavior.

This will fix #163