### PR TITLE
update javascript functionRegex to test for es-next syntax (#203)

### DIFF
--- a/lib/languages/javascript.js
+++ b/lib/languages/javascript.js
@@ -75,7 +75,10 @@ JsParser.prototype.parse_function = function(line) {
     // grab the name out of "name1 = function name2(foo)" preferring name1
     var name = matches.name1 || matches.name2 || '';
     var args = matches.args || matches.arg || null;
-    return [name, args, null];
+
+    // check for async method to set retval to promise
+    var retval = /\basync\b|\*/.test(line) ? 'Promise' : null;
+    return [name, args, retval];
 };
 
 JsParser.prototype.parse_var = function(line) {
@@ -160,6 +163,13 @@ JsParser.prototype.guess_type_from_value = function(val) {
         return (matches[0] && matches[1]) || null;
     }
     return null;
+};
+
+JsParser.prototype.get_function_return_type = function(name, retval) {
+    if(retval) {
+      return retval;
+    }
+    return DocsParser.prototype.get_function_return_type.call(this, name, retval);
 };
 
 module.exports = JsParser;

--- a/lib/languages/javascript.js
+++ b/lib/languages/javascript.js
@@ -44,7 +44,7 @@ JsParser.prototype.parse_function = function(line) {
     var functionRegex = xregexp(
         preFunction +
         //   var foo = 'function 'bar (baz, quaz) {}
-        '((export\\s+((default\\s)*(async\\s+|static\\s+)*))*||(async\\s+||static\\s+))*(?:function(\\*|\\s+\\*)?|get|set)\\s*' +
+        '(?:(?:export\\s+(?:(?:default\\s+)?(?:async\\s+|static\\s+)*))?|(?:async\\s+|static\\s+))?(?:function(:?\\s*\\*)?|get|set)\\s*' +
         //   var foo = function 'bar '(baz, quaz) {}
         '(?:\\s+(?P<name2>' + this.settings.fnIdentifier + '))?\\s*' +
         //   var foo = function bar '(baz, quaz)' {}

--- a/lib/languages/javascript.js
+++ b/lib/languages/javascript.js
@@ -44,7 +44,7 @@ JsParser.prototype.parse_function = function(line) {
     var functionRegex = xregexp(
         preFunction +
         //   var foo = 'function 'bar (baz, quaz) {}
-        '(?:function\\*?|get|set)\\s*' +
+        '(async\\s||export\\s||default\\s||static\\s)*(?:function(\\*|\\s\\*)?|get|set)\\s*' +
         //   var foo = function 'bar '(baz, quaz) {}
         '(?:\\s+(?P<name2>' + this.settings.fnIdentifier + '))?\\s*' +
         //   var foo = function bar '(baz, quaz)' {}

--- a/lib/languages/javascript.js
+++ b/lib/languages/javascript.js
@@ -32,6 +32,7 @@ JsParser.prototype.parse_function = function(line) {
     var preFunction = '^' +
         // '  'var foo = function bar (baz, quaz) {}
         '\\s*' +
+        '(?:export\\s+)?(?:default\\s+)?' +
         //   'var 'foo = function bar (baz, quaz) {}
         '(?:(?:var|let|const)\\s+)?' +
         '(?:' +
@@ -39,8 +40,7 @@ JsParser.prototype.parse_function = function(line) {
             '(?:[a-zA-Z_$][a-zA-Z_$0-9.]*\\.)?' +
             //   var 'foo = 'function bar (baz, quaz) {}
             '(?P<name1>' + this.settings.varIdentifier + ')\\s*[:=]\\s*' +
-        ')?' +
-        '(?:export\\s+)?(?:default\\s+)?';
+        ')?';
 
     var functionRegex = xregexp(
         preFunction +

--- a/lib/languages/javascript.js
+++ b/lib/languages/javascript.js
@@ -39,12 +39,15 @@ JsParser.prototype.parse_function = function(line) {
             '(?:[a-zA-Z_$][a-zA-Z_$0-9.]*\\.)?' +
             //   var 'foo = 'function bar (baz, quaz) {}
             '(?P<name1>' + this.settings.varIdentifier + ')\\s*[:=]\\s*' +
-        ')?';
+        ')?' +
+        '(?:export\\s+)?(?:default\\s+)?';
 
     var functionRegex = xregexp(
         preFunction +
+        // modifiers: static, async
+        '(?:static\\s+)?(?P<promise>async\\s+)?' +
         //   var foo = 'function 'bar (baz, quaz) {}
-        '(?:(?:export\\s+(?:(?:default\\s+)?(?:async\\s+|static\\s+)*))?|(?:async\\s+|static\\s+))?(?:function(:?\\s*\\*)?|get|set)\\s*' +
+        '(?:function(:?\\s*\\*)?|get|set)\\s*' +
         //   var foo = function 'bar '(baz, quaz) {}
         '(?:\\s+(?P<name2>' + this.settings.fnIdentifier + '))?\\s*' +
         //   var foo = function bar '(baz, quaz)' {}
@@ -53,6 +56,7 @@ JsParser.prototype.parse_function = function(line) {
 
     var arrowFunctionRegex = xregexp(
         preFunction +
+        '(?P<promise>async\\s+)?' +
         '(?:'+
             //   var foo = 'bar' => {}
             '(?P<arg>' + this.settings.varIdentifier + ')' +
@@ -77,7 +81,7 @@ JsParser.prototype.parse_function = function(line) {
     var args = matches.args || matches.arg || null;
 
     // check for async method to set retval to promise
-    var retval = /\basync\b|\*/.test(line) ? 'Promise' : null;
+    var retval = matches.promise !== undefined ? 'Promise' : null;
     return [name, args, retval];
 };
 

--- a/lib/languages/javascript.js
+++ b/lib/languages/javascript.js
@@ -44,7 +44,7 @@ JsParser.prototype.parse_function = function(line) {
     var functionRegex = xregexp(
         preFunction +
         //   var foo = 'function 'bar (baz, quaz) {}
-        '(async\\s||export\\s||default\\s||static\\s)*(?:function(\\*|\\s\\*)?|get|set)\\s*' +
+        '((export\\s+((default\\s)*(async\\s+|static\\s+)*))*||(async\\s+||static\\s+))*(?:function(\\*|\\s+\\*)?|get|set)\\s*' +
         //   var foo = function 'bar '(baz, quaz) {}
         '(?:\\s+(?P<name2>' + this.settings.fnIdentifier + '))?\\s*' +
         //   var foo = function bar '(baz, quaz)' {}

--- a/spec/dataset/languages/javascript.yaml
+++ b/spec/dataset/languages/javascript.yaml
@@ -92,11 +92,11 @@ parse_function:
     -
         - should parse anonymous async function
         - async function() {}
-        - ['', null, null]
+        - ['', null, 'Promise']
     -
         - should parse named async function
         - async function foo() {}
-        - ['foo', null, null]
+        - ['foo', null, 'Promise']
     -
         - should parse named static function
         - static function foo() {}
@@ -108,7 +108,7 @@ parse_function:
     -
         - should parse named exported async function
         - export async function foo() {}
-        - ['foo', null, null]
+        - ['foo', null, 'Promise']
     -
         - should parse named exported static function
         - export static function foo() {}
@@ -116,7 +116,7 @@ parse_function:
     -
         - should parse named exported async static function
         - export async static function foo() {}
-        - ['foo', null, null]
+        - ['foo', null, 'Promise']
     -
         - should parse named exported default function
         - export default function foo() {}
@@ -124,11 +124,11 @@ parse_function:
     -
         - should parse named exported default async function
         - export default async function foo() {}
-        - ['foo', null, null]
+        - ['foo', null, 'Promise']
     -
         - should parse named exported default async static function
         - export default async static function foo() {}
-        - ['foo', null, null]
+        - ['foo', null, 'Promise']
     -
         - should parse named exported default static function
         - export default static function foo() {}

--- a/spec/dataset/languages/javascript.yaml
+++ b/spec/dataset/languages/javascript.yaml
@@ -89,7 +89,54 @@ parse_function:
         - should return null, because this is a function call with get key word as name
         - foo.get(bar, 123);
         - null
-
+    -
+        - should parse anonymous async function
+        - async function() {}
+        - ['', null, null]
+    -
+        - should parse named async function
+        - async function foo() {}
+        - ['foo', null, null]
+    -
+        - should parse named static function
+        - static function foo() {}
+        - ['foo', null, null]
+    -
+        - should parse named exported function
+        - export function foo() {}
+        - ['foo', null, null]
+    -
+        - should parse named exported async function
+        - export async function foo() {}
+        - ['foo', null, null]
+    -
+        - should parse named exported static function
+        - export static function foo() {}
+        - ['foo', null, null]
+    -
+        - should parse named exported async static function
+        - export async static function foo() {}
+        - ['foo', null, null]
+    -
+        - should parse named exported default function
+        - export default function foo() {}
+        - ['foo', null, null]
+    -
+        - should parse named exported default async function
+        - export default async function foo() {}
+        - ['foo', null, null]
+    -
+        - should parse named exported default async static function
+        - export default async static function foo() {}
+        - ['foo', null, null]
+    -
+        - should parse named exported default static function
+        - export default static function foo() {}
+        - ['foo', null, null]
+    -
+        - should return null, because this is an invalid function declaration
+        - default export function foo() {}
+        - null
 
 get_arg_type:
     -

--- a/spec/dataset/languages/javascript.yaml
+++ b/spec/dataset/languages/javascript.yaml
@@ -115,7 +115,7 @@ parse_function:
         - ['foo', null, null]
     -
         - should parse named exported async static function
-        - export async static function foo() {}
+        - export static async function foo() {}
         - ['foo', null, 'Promise']
     -
         - should parse named exported default function
@@ -127,7 +127,7 @@ parse_function:
         - ['foo', null, 'Promise']
     -
         - should parse named exported default async static function
-        - export default async static function foo() {}
+        - export default static async function foo() {}
         - ['foo', null, 'Promise']
     -
         - should parse named exported default static function
@@ -137,6 +137,18 @@ parse_function:
         - should return null, because this is an invalid function declaration
         - default export function foo() {}
         - null
+    -
+        - should parse single param async anonymous arrow function
+        - async param => {}
+        - ['', 'param', 'Promise']
+    -
+        - should parse multi param async anonymous arrow function
+        - async (param, param1) => {}
+        - ['', 'param, param1', 'Promise']
+    -
+        - should parse variable declaration with async anonymous arrow function
+        - var foo = async () => {}
+        - ['foo', null, 'Promise']
 
 get_arg_type:
     -


### PR DESCRIPTION
now checks for:
- async
- export
- default

<body>

<footer>