### PR TITLE
Fixes #162

### DIFF
--- a/lib/docblockr-worker.js
+++ b/lib/docblockr-worker.js
@@ -579,7 +579,7 @@ module.exports =
       var text = editor.getTextInBufferRange([start_point, end_point]);
 
       //find the indentation level
-      var regex = /\n(\s*\*)/;
+      var regex = /(\s*\*)/;
       var matches = regex.exec(text);
       var indentation = matches[1].replace(/\t/g, this.repeat(' ', tab_size)).length;
       var line_prefix = matches[1];


### PR DESCRIPTION
The regex wasn't matching the line. I think Atom use to includes newlines on to the beginning of text buffers, this is no longer the case. This fixes the `Wrap Lines` command.

Ref #162 
cc @MoritzKn

Edit: Actually, looks like due to Atom's reporting system, #162 is actually an accumulation of multiple errors, all with the same error message `Uncaught TypeError: Cannot read property '1' of null` - this PR will resolve the issues regarding the wrap lines function, but not all reported in that thread. The issue should remain open.