### PR TITLE
Updated to grab everything associated with the comment

### DIFF
--- a/lib/docblockr-worker.js
+++ b/lib/docblockr-worker.js
@@ -100,7 +100,7 @@ module.exports =
         // extend line comments (// and #)
         else if((self.editor_settings.extend_double_slash == true) && (self.validate_request({preceding:true, preceding_regex:regex.extend_line, scope:'comment.line'}))) {
           // console.log('Snippet Extend line command');
-          var _regex = /^(\s*[^\sa-z0-9!]*\s*).*$/;
+          var _regex = /^(\s*[^\sa-z0-9]*\s*).*$/;
           var editor = atom.workspace.getActiveTextEditor();
           var cursor_position = editor.getCursorBufferPosition();
           var line_text = editor.lineTextForBufferRow(cursor_position.row);

--- a/lib/docblockr-worker.js
+++ b/lib/docblockr-worker.js
@@ -100,7 +100,7 @@ module.exports =
         // extend line comments (// and #)
         else if((self.editor_settings.extend_double_slash == true) && (self.validate_request({preceding:true, preceding_regex:regex.extend_line, scope:'comment.line'}))) {
           // console.log('Snippet Extend line command');
-          var _regex = /^(\s*(?:#|\/\/[\/!]?)\s*).*$/;
+          var _regex = /^(\s*[^\sa-z0-9!]*\s*).*$/;
           var editor = atom.workspace.getActiveTextEditor();
           var cursor_position = editor.getCursorBufferPosition();
           var line_text = editor.lineTextForBufferRow(cursor_position.row);


### PR DESCRIPTION
Pressing enter at the end of the first line will give you the correct second line.

```js
///# @name
///# 
```

Instead of

```js
///# @name
/// 
```