### PR TITLE
Add (optional) support for c-style block comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Master
+* Improve treatment of c-style block comments
+* Add option `c_style_block_comments` to turn on/off c-style block comments.
+
 # 0.8.7 (6 Oct 2016)
 * Fix error when using `Wrap Lines`
 

--- a/README.md
+++ b/README.md
@@ -224,6 +224,8 @@ You can access the configuration settings by entering `Docblockr` in atom settin
 
 - `newline_after_block` *(Boolean)* If true, an extra line break is added after the end of a docblock to separate it from the code. Default `false`
 
+- `c_style_block_comments` *(Boolean)* If true, block comments (starting `/* `) will have asterisks placed on subsequent newlines. Default `false`
+
 ### Note
 All credits for this package goes to [SublimeJsdocs][jsdocs] who have created a wonderful plugin for Sublime Text. I have just ported the package to Atom and Javascript.
 

--- a/lib/docblockr-worker.js
+++ b/lib/docblockr-worker.js
@@ -94,7 +94,6 @@ module.exports =
         // Close block comment
         else if(self.validate_request({preceding:true, preceding_regex:regex.close_block})) {
           // console.log('Snippet close block comment command');
-          var editor = atom.workspace.getActiveTextEditor();
           self.parse_block_command();
         }
         // extend line comments (// and #)
@@ -321,10 +320,12 @@ module.exports =
       string += this.trailing_string;
 
       // Close if needed
-      if (!this.parser.is_existing_comment(this.line)) string += '\n */';
+      if (!this.parser.is_existing_comment(this.line)) {
+          string += '\n */';
+      }
 
       this.write(editor, string);
-    }
+    };
 
     DocBlockrAtom.prototype.trim_auto_whitespace_command = function() {
       /**

--- a/lib/docblockr-worker.js
+++ b/lib/docblockr-worker.js
@@ -64,7 +64,7 @@ module.exports =
           // Snippet-1
           'snippet_1': [/^\s*\/\*$/,/^\*\/\s*$/],
           // Close block comment
-          'close_block': /^\s*\/\*$/,
+          'close_block': /^\s*\/\*\s*$/,
           // extend line
           'extend_line': /^\s*(\/\/[\/!]?|#)/,
           // Extend docblock by adding an asterix at start
@@ -95,7 +95,7 @@ module.exports =
         else if(self.validate_request({preceding:true, preceding_regex:regex.close_block})) {
           // console.log('Snippet close block comment command');
           var editor = atom.workspace.getActiveTextEditor();
-          self.write(editor, '\n$0\n */');
+          self.parse_block_command();
         }
         // extend line comments (// and #)
         else if((self.editor_settings.extend_double_slash == true) && (self.validate_request({preceding:true, preceding_regex:regex.extend_line, scope:'comment.line'}))) {
@@ -292,6 +292,39 @@ module.exports =
         snippet+= '$0';
       this.write(editor, snippet);
     };
+
+    /**
+     * Perform actions for a single-asterix block comment
+     */
+    DocBlockrAtom.prototype.parse_block_command = function () {
+      var editor = atom.workspace.getActiveTextEditor();
+      if (typeof editor === 'undefined' || editor === null) {
+        return;
+      }
+      this.initialize(editor, false);
+
+      // Remove trailing characters (will write them appropriately later)
+      this.erase(editor, this.trailing_range);
+
+      // Build the string to write
+      var string = '\n';
+
+      // Might include asterixes
+      if (this.editor_settings.c_style_block_comments) {
+        string += ' *' + this.indentSpaces;
+      }
+
+      // Write indentation and trailing characters. Place cursor before
+      // trailing characters
+
+      string += '$0';
+      string += this.trailing_string;
+
+      // Close if needed
+      if (!this.parser.is_existing_comment(this.line)) string += '\n */';
+
+      this.write(editor, string);
+    }
 
     DocBlockrAtom.prototype.trim_auto_whitespace_command = function() {
       /**

--- a/lib/docblockr.js
+++ b/lib/docblockr.js
@@ -84,6 +84,10 @@ module.exports = {
             type: 'boolean',
             default: false
         },
+        c_style_block_comments: {
+            type: 'boolean',
+            default: false
+        },
         development_mode: {
             type: 'boolean',
             default: false


### PR DESCRIPTION
Hi, this is an awesome package, thanks.

I use block comments sometimes and noticed that the Docblockr support for these isn't as strong as for full docstrings.

I added an option "c_style_block_comments", defaulting off. With the setting off the current behaviour should be unchanged.

With it on, `/* <enter>` becomes

    /*
     * <cursor here>
     */

And similarly, like when you push enter on the top line of an existing docstring it doesn't create a new one;

    /* <cursor here; user pushes enter>Foo
     * ...
     */

becomes

    /*
     * <cursor here>Foo
     * ...
     */

This is just a light usability tweak but it would be very nice to have.

Cheers
David