### PR TITLE
Prevent exception if arguments can't be parsed

### DIFF
--- a/lib/languages/javascript.js
+++ b/lib/languages/javascript.js
@@ -137,7 +137,7 @@ JsParser.prototype.get_arg_name = function(arg) {
 
     var matches = this.parse_arg(arg);
 
-    if (matches.value) {
+    if (matches && matches.value) {
       return util.format('[%s=%s]', matches.name, matches.value);
     }
 


### PR DESCRIPTION
when I input some code like this
```javascript
function func ({}) {}
```
and then input `/**` to use docblockr
`Uncaught TypeError: Cannot read property 'value' of null `