### PR TITLE
Fix typo regarding return type in DocsParser.prototype.format_function (#251)

### DIFF
--- a/lib/docsparser.js
+++ b/lib/docsparser.js
@@ -155,9 +155,9 @@ DocsParser.prototype.format_function = function(name, args, retval, options) {
         type_info = '';
         if(this.settings.typeInfo) {
             if (this.settings.curlyTypes) {
-                type_info = util.format(' ${1:%s}', ret_type || '[type]');
+                type_info = util.format(' {${1:%s}}', ret_type || '[type]');
             } else {
-                type_info = util.format(' {${1:%s}', ret_type || '[type]');
+                type_info = util.format(' ${1:%s}', ret_type || '[type]');
             }
         }
 


### PR DESCRIPTION
Fixes issue #251 