### PR TITLE
Fix/135/docked editor handling

### DIFF
--- a/lib/docblockr-worker.js
+++ b/lib/docblockr-worker.js
@@ -88,7 +88,7 @@ module.exports =
         }
         else if(self.validate_request({preceding:true, preceding_regex:regex.snippet_1[0], following:true, following_regex:regex.snippet_1[1]})) {
           // console.log('Snippet-1 command');
-          var editor = atom.workspace.getActiveTextEditor();
+          var editor = self.get_relevant_editor();
           self.write(editor, '\n$0\n ');
         }
         // Close block comment
@@ -100,7 +100,7 @@ module.exports =
         else if((self.editor_settings.extend_double_slash == true) && (self.validate_request({preceding:true, preceding_regex:regex.extend_line, scope:'comment.line'}))) {
           // console.log('Snippet Extend line command');
           var _regex = /^(\s*[^\sa-z0-9]*\s*).*$/;
-          var editor = atom.workspace.getActiveTextEditor();
+          var editor = self.get_relevant_editor();
           var cursor_position = editor.getCursorBufferPosition();
           var line_text = editor.lineTextForBufferRow(cursor_position.row);
           line_text = line_text.replace(_regex, '$1');
@@ -110,7 +110,7 @@ module.exports =
         else if(self.validate_request({preceding:true, preceding_regex:regex.extend, scope:'comment.block'})) {
           // console.log('Snippet Extend command');
           var _regex = /^(\s*\*\s*).*$/;
-          var editor = atom.workspace.getActiveTextEditor();
+          var editor = self.get_relevant_editor();
           var cursor_position = editor.getCursorBufferPosition();
           var line_text = editor.lineTextForBufferRow(cursor_position.row);
           line_text = line_text.replace(_regex, '$1');
@@ -128,7 +128,7 @@ module.exports =
         if(self.validate_request({preceding:true, preceding_regex:_regex}))
           self.parse_command(true);
         else {
-          var editor = atom.workspace.getActiveTextEditor();
+          var editor = self.get_relevant_editor();
           editor.insertNewline();
           //event.abortKeyBinding();
         }
@@ -200,7 +200,7 @@ module.exports =
       var following_regex = (typeof options.following_regex !== 'undefined') ? options.following_regex : '';
       var scope     = (typeof options.scope !== 'undefined') ? options.scope : false;
 
-      var editor = atom.workspace.getActiveTextEditor();
+      var editor = this.get_relevant_editor(event);
       this.cursors = [];
       var cursor, i, len, following_text, preceding_text;
 
@@ -269,7 +269,7 @@ module.exports =
     };
 
     DocBlockrAtom.prototype.parse_command = function(inline) {
-      var editor = atom.workspace.getActiveTextEditor();
+      var editor = this.get_relevant_editor();
       if (typeof editor === 'undefined' || editor === null) {
         return;
       }
@@ -296,7 +296,7 @@ module.exports =
      * Perform actions for a single-asterix block comment
      */
     DocBlockrAtom.prototype.parse_block_command = function () {
-      var editor = atom.workspace.getActiveTextEditor();
+      var editor = this.get_relevant_editor();
       if (typeof editor === 'undefined' || editor === null) {
         return;
       }
@@ -331,7 +331,7 @@ module.exports =
       /**
        * Trim the automatic whitespace added when creating a new line in a docblock.
        */
-      var editor = atom.workspace.getActiveTextEditor();
+      var editor = this.get_relevant_editor();
       if (typeof editor === 'undefined' || editor === null) {
         return;
       }
@@ -347,7 +347,7 @@ module.exports =
     };
 
     DocBlockrAtom.prototype.indent_command = function() {
-      var editor = atom.workspace.getActiveTextEditor();
+      var editor = this.get_relevant_editor();
       var current_pos = editor.getCursorBufferPosition();
       var prev_line = editor.lineTextForBufferRow(current_pos.row - 1);
       var spaces = this.get_indent_spaces(editor, prev_line);
@@ -370,7 +370,7 @@ module.exports =
     };
 
     DocBlockrAtom.prototype.join_command = function() {
-      var editor = atom.workspace.getActiveTextEditor();
+      var editor = this.get_relevant_editor();
       var selections = editor.getSelections();
       var i, j, len, row_begin;
       var text_with_ending = function(row) {
@@ -405,7 +405,7 @@ module.exports =
     };
 
     DocBlockrAtom.prototype.decorate_command = function() {
-      var editor = atom.workspace.getActiveTextEditor();
+      var editor = this.get_relevant_editor();
       var pos = editor.getCursorBufferPosition();
       var whitespace_re = /^(\s*)\/\//;
       var scope_range = this.scope_range(editor, pos, 'comment.line.double-slash');
@@ -444,7 +444,7 @@ module.exports =
     };
 
     DocBlockrAtom.prototype.decorate_multiline_command = function() {
-      var editor = atom.workspace.getActiveTextEditor();
+      var editor = this.get_relevant_editor();
       var pos = editor.getCursorBufferPosition();
       var whitespace_re = /^(\s*)\/\*/;
       var tab_size = atom.config.get('editor.tabLength');
@@ -519,7 +519,7 @@ module.exports =
        *//*|   <-- from here
       |      <-- to here
        */
-      var editor = atom.workspace.getActiveTextEditor();
+      var editor = this.get_relevant_editor();
       var cursor = editor.getCursorBufferPosition();
       var text = editor.lineTextForBufferRow(cursor.row);
       text = text.replace(/^(\s*)\s\*\/.*/, '\n$1');
@@ -532,7 +532,7 @@ module.exports =
       var tab_stop = function(m, g1) {
         return util.format('${%d:%s}', tab_index(), g1);
       };
-      var editor = atom.workspace.getActiveTextEditor();
+      var editor = this.get_relevant_editor();
       var pos = editor.getCursorBufferPosition();
       var Snippets = atom.packages.activePackages.snippets.mainModule;
       // disable all snippet expansions
@@ -561,7 +561,7 @@ module.exports =
        *  Wrap column is set by the first ruler (set in Default.sublime-settings), or 80 by default.
        * Shortcut Key: alt+q
        */
-      var editor = atom.workspace.getActiveTextEditor();
+      var editor = this.get_relevant_editor();
       var pos = editor.getCursorBufferPosition();
       var tab_size = atom.config.get('editor.tabLength');
       var wrap_len = atom.config.get('editor.preferredLineLength');
@@ -803,6 +803,13 @@ module.exports =
         i++;
       }
       return a;
+    }; 
+    
+    DocBlockrAtom.prototype.get_relevant_editor = function() {
+        var editor = atom.workspace.getActiveTextEditor();
+        if (editor !== undefined)
+            return editor;
+        return null;
     };
 
     DocBlockrAtom.prototype.read_line = function(editor, point) {

--- a/lib/docblockr-worker.js
+++ b/lib/docblockr-worker.js
@@ -807,10 +807,14 @@ module.exports =
     
     DocBlockrAtom.prototype.get_relevant_editor = function() {
         var editor = atom.workspace.getActiveTextEditor();
+        var atomTextEditor;
         if (editor !== undefined)
             return editor;
-        if (this.event && this.event.target)
-            return this.event.target.getModel();
+        if (this.event && this.event.target) {
+            atomTextEditor = this.event.target.getClosest('atom-text-editor');
+            if (atomTextEditor)
+                return atomTextEditor.getModel();
+        }
         return null;
     };
 

--- a/lib/docblockr-worker.js
+++ b/lib/docblockr-worker.js
@@ -809,6 +809,8 @@ module.exports =
         var editor = atom.workspace.getActiveTextEditor();
         if (editor !== undefined)
             return editor;
+        if (this.event && this.event.target)
+            return this.event.target.getModel();
         return null;
     };
 


### PR DESCRIPTION
Improve method for obtaining active text editor so that non-standard editors (such as the new GitHub commit message editor) are handled correctly.