### PR TITLE
Add support for Processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The package currently supports the following languages -
 * JavaScript
 * ObjC, ObjC++
 * PHP
+* Processing
 * Rust
 * SASS
 * TypeScript

--- a/lib/docblockr-worker.js
+++ b/lib/docblockr-worker.js
@@ -8,6 +8,7 @@ var Parsers = {
   ObjCParser: require("./languages/objc"),
   JavaParser: require("./languages/java"),
   TypescriptParser: require("./languages/typescript"),
+  ProcessingParser: require("./languages/processing"),
 };
 
 var escape = require('./utils').escape;
@@ -891,6 +892,8 @@ module.exports =
           return new Parsers.RustParser(settings);
       else if(source_lang === 'ts')
           return new Parsers.TypescriptParser(settings);
+      else if(source_lang === 'processing')
+          return new Parsers.ProcessingParser(settings);
       return new Parsers.JsParser(settings);
     };
 

--- a/lib/languages/processing.js
+++ b/lib/languages/processing.js
@@ -1,0 +1,8 @@
+var JavaParser = require("./java");
+
+function ProcessingParser(settings) {
+    JavaParser.call(this, settings);
+}
+ProcessingParser.prototype = Object.create(JavaParser.prototype);
+
+module.exports = ProcessingParser;

--- a/spec/dataset/languages/processing.yaml
+++ b/spec/dataset/languages/processing.yaml
@@ -1,0 +1,34 @@
+name: ProcessingParser
+
+parse_function:
+    -
+        - should parse a simple method
+        - void foo() {}
+        - ['foo', null, 'void', null]
+    -
+        - should parse a method with one argument
+        - void foo(int foo) {}
+        - ['foo', 'int foo', 'void', null]
+    -
+        - should parse a method with multiple arguments
+        - void foo(int bar, Boolean baz) {}
+        - ['foo', 'int bar, Boolean baz', 'void', null]
+    -
+        - should parse a method with return type
+        - String foo() {}
+        - ['foo', null, 'String', null]
+    -
+        - should parse a method with array return type
+        - char[] foo() {}
+        - ['foo', null, 'char[]', null]
+
+
+get_function_return_type:
+    -
+        - should return `null` because `void` methods have no return
+        - ['fooBar', 'void']
+        - null
+    -
+        - should return the retval
+        - ['fooBar', 'String']
+        - 'String'

--- a/spec/language.spec.js
+++ b/spec/language.spec.js
@@ -9,6 +9,7 @@ import ActionscriptParser from '../lib/languages/actionscript';
 import ObjCParser from '../lib/languages/objc';
 import JavaParser from '../lib/languages/java';
 import TypescriptParser from '../lib/languages/typescript';
+import ProcessingParser from '../lib/languages/processing';
 
 import fs from 'fs';
 import path from 'path';
@@ -25,6 +26,7 @@ let parsers = {
     ObjCParser,
     JavaParser,
     TypescriptParser,
+    ProcessingParser,
 };
 
 var filepath = path.resolve(path.join(__dirname, 'dataset/languages'));


### PR DESCRIPTION
Adds support for [processing](https://processing.org/) by extending the Java parser as suggested by @audreyseo.