### PR TITLE
Check `event.target` before `getActiveTextEditor()`

### DIFF
--- a/lib/docblockr-worker.js
+++ b/lib/docblockr-worker.js
@@ -806,15 +806,15 @@ module.exports =
     }; 
 
     DocBlockrAtom.prototype.get_relevant_editor = function() {
-        var editor = atom.workspace.getActiveTextEditor();
-        var atomTextEditor;
-        if (editor !== undefined)
-            return editor;
+        var editor, atomTextEditor;
         if (this.event && this.event.target) {
             atomTextEditor = this.event.target.closest('atom-text-editor');
             if (atomTextEditor)
                 return atomTextEditor.getModel();
         }
+        editor = atom.workspace.getActiveTextEditor()
+        if (editor !== undefined)
+            return editor;
         return null;
     };
 


### PR DESCRIPTION
This fixes a subtle bug related to text inputs in Atom's docks. I introduced the bug myself in #266, so I suppose it's only fair that I fix it.

## Reproducing the problem

1. Open a JavaScript file containing a multiline comment.
2. Place the cursor within the multiline comment.
3. Click into the "Commit message" box in the GitHub integration.
4. Press <kbd>Enter</kbd>.

## Expected

- Newline added to "Commit message".

## Actual

- Newline added to comment in active text editor.

## Fix

- Look first for the editor attached to the keyboard event, rather than using `atom.workspace.getActiveTextEditor()` first.