### PR TITLE
Handle ES2015 generator shorthand for Object

### DIFF
--- a/lib/docsparser.js
+++ b/lib/docsparser.js
@@ -16,6 +16,11 @@ DocsParser.prototype.init = function(viewSettings) {
 };
 
 DocsParser.prototype.is_existing_comment = function(line) {
+    // handle ES2015 generator shorhand for Object
+    // example: * funcname(var) {}
+    if (line.search(/^\s*\*\s?[\$\_A-Za-z][\$\_\w]+\s?\([\$\_A-Za-z][\$\_\w]+\)\s?\{/) >= 0) {
+        return false;
+    }
     return ((line.search(/^\s*\*/) >=0) ? true : false);
 };
 

--- a/lib/docsparser.js
+++ b/lib/docsparser.js
@@ -16,12 +16,7 @@ DocsParser.prototype.init = function(viewSettings) {
 };
 
 DocsParser.prototype.is_existing_comment = function(line) {
-    // handle ES2015 generator shorhand for Object
-    // example: * funcname(var) {}
-    if (line.search(/^\s*\*\s?[\$\_A-Za-z][\$\_\w]+\s?\([\$\_A-Za-z][\$\_\w]+\)\s?\{/) >= 0) {
-        return false;
-    }
-    return ((line.search(/^\s*\*/) >=0) ? true : false);
+    return /^\s*\*/.test(line);
 };
 
 DocsParser.prototype.is_numeric = function(val) {

--- a/lib/languages/javascript.js
+++ b/lib/languages/javascript.js
@@ -222,4 +222,14 @@ JsParser.prototype.get_function_return_type = function(name, retval) {
     return DocsParser.prototype.get_function_return_type.call(this, name, retval);
 };
 
+JsParser.prototype.is_existing_comment = function(line) {
+    // handle ES2015 generator shorhand for Object
+    // example: * funcName(arg1, arg2, ...restArg) {}
+    if (/^\s*\*\s*[$_A-Za-z][\$\w]+\s*\(.*?\)\s*\{/.test(line)) {
+        return false;
+    }
+    return /^\s*\*/.test(line);
+};
+
+
 module.exports = JsParser;

--- a/spec/dataset/languages/javascript.yaml
+++ b/spec/dataset/languages/javascript.yaml
@@ -341,3 +341,13 @@ get_function_return_type:
         - should return false because no type could be detected
         - [foo, null]
         - false
+
+is_existing_comment:
+    -
+        - should return true if line begins with "*"
+        - "* comment"
+        - true
+    -
+        - should return false if line is a object generator shorthand
+        - "* funcName(arg1, arg2, ...restArg) {}"
+        - false


### PR DESCRIPTION
Example: 

```js
const object = {
  * funcName(var) {}
  *funcName(var) {}
}
```

The leading asterisk will be processed as a mark of exist comment before, so I made a little fix to bypass it.