### PR TITLE
Feature: Typescript/Typedoc updates

### DIFF
--- a/lib/docsparser.js
+++ b/lib/docsparser.js
@@ -178,7 +178,7 @@ DocsParser.prototype.format_function = function(name, args, retval, options) {
     // return value type might be already available in some languages but
     // even then ask language specific parser if it wants it listed
     var ret_type = this.get_function_return_type(name, retval);
-    if(ret_type !== null && name !== 'constructor') {
+    if(ret_type !== null) {
         type_info = '';
         if(this.settings.typeInfo) {
             if (this.settings.curlyTypes) {

--- a/lib/docsparser.js
+++ b/lib/docsparser.js
@@ -178,7 +178,7 @@ DocsParser.prototype.format_function = function(name, args, retval, options) {
     // return value type might be already available in some languages but
     // even then ask language specific parser if it wants it listed
     var ret_type = this.get_function_return_type(name, retval);
-    if(ret_type !== null) {
+    if(ret_type !== null && name !== 'constructor') {
         type_info = '';
         if(this.settings.typeInfo) {
             if (this.settings.curlyTypes) {

--- a/lib/docsparser.js
+++ b/lib/docsparser.js
@@ -87,9 +87,12 @@ DocsParser.prototype.format_var = function(name, val, valType) {
     else {
         temp = util.format('${1:[%s description]}', escape(name));
         out.push(temp);
-        temp = util.format('@%s %s${1:%s}%s',
-                                this.settings.typeTag, brace_open, valType, brace_close);
-        out.push(temp);
+
+        if (this.settings.typeInfo) {
+            temp = util.format('@%s %s${1:%s}%s',
+                                    this.settings.typeTag, brace_open, valType, brace_close);
+            out.push(temp);
+        }
     }
     return out;
 };
@@ -152,12 +155,19 @@ DocsParser.prototype.format_function = function(name, args, retval, options) {
             var arg_type = parsed_args[i][0];
             var arg_name = parsed_args[i][1];
 
-            type_info = this.get_type_info(arg_type, arg_name);
-            format_str = '@param %s%s';
+            format_str = '@param %s';
+            if(this.settings.typeInfo) {
+                type_info = this.get_type_info(arg_type, arg_name);
+                format_str += '%s';
+            }
             if(this.editor_settings.param_description) {
                 format_str += ' ${1:[description]}';
             }
-            out.push(util.format(format_str, type_info, escape(arg_name)));
+            if(this.settings.typeInfo) {
+                out.push(util.format(format_str, type_info, escape(arg_name)));
+            } else {
+                out.push(util.format(format_str, escape(arg_name)));
+            }
         }
     }
 

--- a/lib/languages/typescript.js
+++ b/lib/languages/typescript.js
@@ -83,6 +83,7 @@ TypescriptParser.prototype.parse_var = function(line) {
 };
 
 TypescriptParser.prototype.get_function_return_type = function(name, retval) {
+    if(name === 'constructor') { return null; }
     return ((retval != 'void') ? retval : null);
 };
 

--- a/lib/languages/typescript.js
+++ b/lib/languages/typescript.js
@@ -16,7 +16,7 @@ TypescriptParser.prototype.setup_settings = function() {
         'commentType': 'block',
         // curly brackets around the type information
         'curlyTypes': true,
-        'typeInfo': true,
+        'typeInfo': false,
         'typeTag': 'type',
         // technically, they can contain all sorts of unicode, but w/e
         'varIdentifier': identifier,

--- a/lib/languages/typescript.js
+++ b/lib/languages/typescript.js
@@ -63,6 +63,9 @@ TypescriptParser.prototype.get_arg_name = function(arg) {
     if(arg.indexOf(':') > -1)
         arg = arg.split(':')[0];
 
+    var pubPrivPattern = /\b(public|private)\s+|/g;
+    arg = arg.replace(pubPrivPattern, '');
+
     var regex = /[ \?]/g;
     return arg.replace(regex, '');
 };


### PR DESCRIPTION
This is an updated version of #172. It should address: #134, #201, #242, #243

I've tried to implement the original review suggestions into this as well as maintain code style with what already existed.

The original goals were:

- function `@param`s should not include type
- constructor functions should not have `@return`
- constructor function argument name parser should strip `public` and `private` keywords
- var block should not include `@type`

  