### PR TITLE
Remove returns for constructors in Java

### DIFF
--- a/lib/languages/java.js
+++ b/lib/languages/java.js
@@ -89,7 +89,7 @@ JavaParser.prototype.format_function = function(name, args, retval, throws_args,
 };
 
 JavaParser.prototype.get_function_return_type = function(name, retval) {
-    if(retval === 'void')
+    if(retval === 'void' || name === 'constructor')
         return null;
     else
         return retval;


### PR DESCRIPTION
Documented here: http://www.oracle.com/technetwork/java/javase/documentation/index-137868.html#@return
> Omit @return for methods that return void and for constructors

closes #243