### PR TITLE
Fix adherence to preferred line length

### DIFF
--- a/lib/docblockr-worker.js
+++ b/lib/docblockr-worker.js
@@ -569,6 +569,7 @@ module.exports =
       var pos = editor.getCursorBufferPosition();
       var tab_size = atom.config.get('editor.tabLength');
       var wrap_len = atom.config.get('editor.preferredLineLength');
+      var grammar_wrap_len = atom.config.get('editor.preferredLineLength', { scope: editor.getRootScopeDescriptor() } ) || wrap_len;
 
       var num_indent_spaces = Math.max(0, (this.editor_settings.indentation_spaces ? this.editor_settings.indentation_spaces : 1));
       var indent_spaces = this.repeat(' ', num_indent_spaces);
@@ -632,6 +633,7 @@ module.exports =
         var words = para.trim().split(' ');
         var text = '\n';
         var line = line_prefix + indent_spaces;
+        var unPrefixedLine = indent_spaces;
         var line_tagged = false; // indicates if the line contains a doc tag
         var para_tagged = false; // indicates if this paragraph contains a doc tag
         var line_is_new = true;
@@ -648,18 +650,19 @@ module.exports =
             tag = word;
           }
 
-          if((line.length + word.length) > wrap_len) {
-            // appending the word to the current line would exceed its
-            // length requirements
+          if((unPrefixedLine.length + indent_spaces_same_para.length + word.length) > indentation + wrap_len
+              || (indentation + unPrefixedLine.length + indent_spaces_same_para.length + word.length) > grammar_wrap_len) {
             text+= line.replace(/\s+$/, '') + '\n';
             line = line_prefix + indent_spaces_same_para + word + ' ';
+            unPrefixedLine = indent_spaces_same_para + word + ' ';
             line_tagged = false;
             line_is_new = true;
           }
           else {
             line+= word + ' ';
+            unPrefixedLine+= word + ' ';
+            line_is_new = false;
           }
-          line_is_new = false;
         }
         text+= line.replace(/\s+$/, '');
 


### PR DESCRIPTION
## Description
- Consider both settings:
  1. Preferred line length as a global setting.
  2. Preferred line length as a grammar-specific setting.
- Fix line length comparison to account for the above. Also, instead of comparing line length to `line.length`, which includes `line_prefix` that potentially contains tabs, compare line length to an unprefixed line length. This results in more accurate wrapping in all scenarios.

---

This was a result of my work on a WordPress project, where the [coding standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/#line-wrapping) request that:

> DocBlock text should wrap to the next line after 80 characters of text. If the DocBlock itself is indented on the left 20 character positions, the wrap could occur at position 100, but should not extend beyond a total of 120 characters wide.

With these changes, DocBlockr in Atom now makes this possible.

## TODO

I'm not sure if this matches Sublime or not. Maybe someone else knows?