### PR TITLE
Fixed Sass comment block incorrectly expanding

### DIFF
--- a/lib/languages/sass.js
+++ b/lib/languages/sass.js
@@ -13,11 +13,11 @@ SassParser.prototype = Object.create(DocsParser.prototype);
 SassParser.prototype.setup_settings = function() {
     var identifier = '[a-zA-Z_-][a-zA-Z_0-9-]*';
     this.settings = {
-        'commentType': 'single',
+        'commentType': 'block',
         'curlyTypes': true,
         'typeInfo': true,
         'typeTag': 'type',
-        'prefix': '///',
+        'commentCloser': ' */',
         'varIdentifier': '\\$' + identifier,
         'fnIdentifier':  identifier,
         'fnOpener': '@(?:mixin|function)\\s+' + identifier + '\\s*[\\(|\\{]',


### PR DESCRIPTION
Fixes #313 

Changed the behaviour to expand to:
```
/**
 *
 */
```

Rather than the current method of:
```
/**
/// 
```

Which causes the entire document to become commented out.