### PR TITLE
修复extra_tags

### DIFF
--- a/lib/docblockr-worker.js
+++ b/lib/docblockr-worker.js
@@ -25,6 +25,11 @@ module.exports =
     function DocBlockrAtom() {
       var self = this;
       var settings = atom.config.get('docblockr');
+      // 修复在自定义额外参数的时候无法使用逗号的问题
+      settings.extra_tags = settings.extra_tags.split(/[^\\],/)
+      for (var key in settings.extra_tags) {
+          settings.extra_tags[key] = settings.extra_tags[key].replace('\\,', ',')
+      }
       this.editor_settings = settings;
 
       atom.config.observe('docblockr', function() {


### PR DESCRIPTION
修复extra_tags参数在自定义的时候无法使用逗号的问题