### PR TITLE
Migrate to `class` syntax throughout the project

### DIFF
--- a/lib/docblockr-worker.js
+++ b/lib/docblockr-worker.js
@@ -15,969 +15,970 @@ const Parsers = {
 const escape = require('./utils').escape;
 const util = require('util');
 // const Snippets = global.atom.packages.activePackages.snippets.mainModule;
+class DocBlockrAtom {
+  constructor () {
+    const self = this;
+    const settings = global.atom.config.get('docblockr');
+    this.editor_settings = settings;
 
-function DocBlockrAtom () {
-  const self = this;
-  const settings = global.atom.config.get('docblockr');
-  this.editor_settings = settings;
+    global.atom.config.observe('docblockr', function () {
+      self.update_config();
+    });
 
-  global.atom.config.observe('docblockr', function () {
-    self.update_config();
-  });
+    global.atom.commands.add('atom-workspace', 'docblockr:parse-tab', function (event) {
+      self.event = event;
+      const regex = {
+        // Parse Command
+        parse: /^\s*(\/\*([*!])|###\*|\/\/\*)\s*$/,
+        // Indent Command
+        indent: /^(\s*\*|\/\/\/)\s*$/
+      };
 
-  global.atom.commands.add('atom-workspace', 'docblockr:parse-tab', function (event) {
-    self.event = event;
-    const regex = {
-      // Parse Command
-      parse: /^\s*(\/\*([*!])|###\*|\/\/\*)\s*$/,
-      // Indent Command
-      indent: /^(\s*\*|\/\/\/)\s*$/
-    };
+      if (self.validate_request({ preceding: true, precedingRegex: regex.parse })) {
+        // Parse Command
+        self.parse_command(false);
+      } else if (self.validate_request({ preceding: true, precedingRegex: regex.indent })) {
+        // Indent Command
+        self.indent_command();
+      } else { self.event.abortKeyBinding(); }
+    });
 
-    if (self.validate_request({ preceding: true, precedingRegex: regex.parse })) {
-      // Parse Command
-      self.parse_command(false);
-    } else if (self.validate_request({ preceding: true, precedingRegex: regex.indent })) {
-      // Indent Command
-      self.indent_command();
-    } else { self.event.abortKeyBinding(); }
-  });
+    global.atom.commands.add('atom-workspace', 'docblockr:parse-enter', function (event) {
+      self.event = event;
+      const regex = {
+        // Parse Command
+        parse: /^\s*(\/\*([*!])|###\*|\/\/\*)\s*$/,
+        // Trim auto whitespace
+        trim_auto: [/^\s*\*\s*$/, /^\s*$/],
+        // Deindent Command
+        deindent: /^\s+\*\//,
+        // Snippet-1
+        snippet_1: [/^\s*\/\*$/, /^\*\/\s*$/],
+        // Close block comment
+        close_block: /^\s*\/\*\s*$/,
+        // extend line
+        extend_line: /^\s*(\/\/[/!]?|#)/,
+        // Extend docblock by adding an asterix at start
+        extend: /^\s*\*(?:.?|.*(?:[^*][^/]|[^*]\/|\*[^/]))\s*$/
+      };
 
-  global.atom.commands.add('atom-workspace', 'docblockr:parse-enter', function (event) {
-    self.event = event;
-    const regex = {
-      // Parse Command
-      parse: /^\s*(\/\*([*!])|###\*|\/\/\*)\s*$/,
-      // Trim auto whitespace
-      trim_auto: [/^\s*\*\s*$/, /^\s*$/],
-      // Deindent Command
-      deindent: /^\s+\*\//,
-      // Snippet-1
-      snippet_1: [/^\s*\/\*$/, /^\*\/\s*$/],
-      // Close block comment
-      close_block: /^\s*\/\*\s*$/,
-      // extend line
-      extend_line: /^\s*(\/\/[/!]?|#)/,
-      // Extend docblock by adding an asterix at start
-      extend: /^\s*\*(?:.?|.*(?:[^*][^/]|[^*]\/|\*[^/]))\s*$/
-    };
+      if (self.validate_request({ preceding: true, precedingRegex: regex.parse })) {
+        // Parse Command
+        self.parse_command(false);
+      } else if (self.validate_request({ preceding: true, precedingRegex: regex.trim_auto[0], following: true, followingRegex: regex.trim_auto[1], scope: 'comment.block' })) {
+        // Trim auto whitespace
+        self.trim_auto_whitespace_command();
+      } else if (self.validate_request({ preceding: true, precedingRegex: regex.deindent })) {
+        // Deindent command
+        self.deindent_command();
+      } else if (self.validate_request({ preceding: true, precedingRegex: regex.snippet_1[0], following: true, followingRegex: regex.snippet_1[1] })) {
+        // Snippet-1 command
+        const editor = self.get_relevant_editor();
+        self.write(editor, '\n$0\n ');
+      } else if (self.validate_request({ preceding: true, precedingRegex: regex.close_block })) {
+        // Close block comment command
+        self.parse_block_command();
+      } else if ((self.editor_settings.extend_double_slash === true) && (self.validate_request({ preceding: true, precedingRegex: regex.extend_line, scope: 'comment.line' }))) {
+        // Extend line comments (// and #)
+        const _regex = /^(\s*[^\sa-z0-9]*\s*).*$/;
+        const editor = self.get_relevant_editor();
+        const cursorPosition = editor.getCursorBufferPosition();
+        let lineText = editor.lineTextForBufferRow(cursorPosition.row);
+        lineText = lineText.replace(_regex, '$1');
+        editor.insertText('\n' + lineText);
+      } else if (self.validate_request({ preceding: true, precedingRegex: regex.extend, scope: 'comment.block' })) {
+        // Extend docblock by adding an asterix at start
+        const _regex = /^(\s*\*\s*).*$/;
+        const editor = self.get_relevant_editor();
+        const cursorPosition = editor.getCursorBufferPosition();
+        let lineText = editor.lineTextForBufferRow(cursorPosition.row);
+        lineText = lineText.replace(_regex, '$1');
+        editor.insertText('\n' + lineText);
+      } else { self.event.abortKeyBinding(); }
+    });
 
-    if (self.validate_request({ preceding: true, precedingRegex: regex.parse })) {
-      // Parse Command
-      self.parse_command(false);
-    } else if (self.validate_request({ preceding: true, precedingRegex: regex.trim_auto[0], following: true, followingRegex: regex.trim_auto[1], scope: 'comment.block' })) {
-      // Trim auto whitespace
-      self.trim_auto_whitespace_command();
-    } else if (self.validate_request({ preceding: true, precedingRegex: regex.deindent })) {
-      // Deindent command
-      self.deindent_command();
-    } else if (self.validate_request({ preceding: true, precedingRegex: regex.snippet_1[0], following: true, followingRegex: regex.snippet_1[1] })) {
-      // Snippet-1 command
-      const editor = self.get_relevant_editor();
-      self.write(editor, '\n$0\n ');
-    } else if (self.validate_request({ preceding: true, precedingRegex: regex.close_block })) {
-      // Close block comment command
-      self.parse_block_command();
-    } else if ((self.editor_settings.extend_double_slash === true) && (self.validate_request({ preceding: true, precedingRegex: regex.extend_line, scope: 'comment.line' }))) {
-      // Extend line comments (// and #)
-      const _regex = /^(\s*[^\sa-z0-9]*\s*).*$/;
-      const editor = self.get_relevant_editor();
-      const cursorPosition = editor.getCursorBufferPosition();
-      let lineText = editor.lineTextForBufferRow(cursorPosition.row);
-      lineText = lineText.replace(_regex, '$1');
-      editor.insertText('\n' + lineText);
-    } else if (self.validate_request({ preceding: true, precedingRegex: regex.extend, scope: 'comment.block' })) {
-      // Extend docblock by adding an asterix at start
-      const _regex = /^(\s*\*\s*).*$/;
-      const editor = self.get_relevant_editor();
-      const cursorPosition = editor.getCursorBufferPosition();
-      let lineText = editor.lineTextForBufferRow(cursorPosition.row);
-      lineText = lineText.replace(_regex, '$1');
-      editor.insertText('\n' + lineText);
-    } else { self.event.abortKeyBinding(); }
-  });
+    global.atom.commands.add('atom-workspace', 'docblockr:parse-inline', function (event) {
+      self.event = event;
+      // console.log('Parse-Inline command');
+      const _regex = /^\s*\/\*{2}$/;
 
-  global.atom.commands.add('atom-workspace', 'docblockr:parse-inline', function (event) {
-    self.event = event;
-    // console.log('Parse-Inline command');
-    const _regex = /^\s*\/\*{2}$/;
+      if (self.validate_request({ preceding: true, precedingRegex: _regex })) { self.parse_command(true); } else {
+        const editor = self.get_relevant_editor();
+        editor.insertNewline();
+        // event.abortKeyBinding();
+      }
+    });
 
-    if (self.validate_request({ preceding: true, precedingRegex: _regex })) { self.parse_command(true); } else {
-      const editor = self.get_relevant_editor();
-      editor.insertNewline();
-      // event.abortKeyBinding();
-    }
-  });
+    global.atom.commands.add('atom-workspace', 'docblockr:join', function (event) {
+      self.event = event;
+      // console.log('Join command');
+      if (self.validate_request({ scope: 'comment.block' })) { self.join_command(); }
+    });
 
-  global.atom.commands.add('atom-workspace', 'docblockr:join', function (event) {
-    self.event = event;
-    // console.log('Join command');
-    if (self.validate_request({ scope: 'comment.block' })) { self.join_command(); }
-  });
+    global.atom.commands.add('atom-workspace', 'docblockr:reparse', function (event) {
+      self.event = event;
+      // console.log('Reparse command');
+      if (self.validate_request({ scope: 'comment.block' })) { self.reparse_command(); }
+    });
 
-  global.atom.commands.add('atom-workspace', 'docblockr:reparse', function (event) {
-    self.event = event;
-    // console.log('Reparse command');
-    if (self.validate_request({ scope: 'comment.block' })) { self.reparse_command(); }
-  });
+    global.atom.commands.add('atom-workspace', 'docblockr:wrap-lines', function (event) {
+      self.event = event;
+      // console.log('Wraplines command');
+      if (self.validate_request({ scope: 'comment.block' })) { self.wrap_lines_command(); }
+    });
 
-  global.atom.commands.add('atom-workspace', 'docblockr:wrap-lines', function (event) {
-    self.event = event;
-    // console.log('Wraplines command');
-    if (self.validate_request({ scope: 'comment.block' })) { self.wrap_lines_command(); }
-  });
+    global.atom.commands.add('atom-workspace', 'docblockr:decorate', function (event) {
+      self.event = event;
+      // console.log('Decorate command');
+      if (self.validate_request({ scope: 'comment.line.double-slash' })) { self.decorate_command(); }
+    });
 
-  global.atom.commands.add('atom-workspace', 'docblockr:decorate', function (event) {
-    self.event = event;
-    // console.log('Decorate command');
-    if (self.validate_request({ scope: 'comment.line.double-slash' })) { self.decorate_command(); }
-  });
+    global.atom.commands.add('atom-workspace', 'docblockr:decorate-multiline', function (event) {
+      self.event = event;
+      // console.log('Decorate Multiline command');
+      if (self.validate_request({ scope: 'comment.block' })) { self.decorate_multiline_command(); }
+    });
+  }
 
-  global.atom.commands.add('atom-workspace', 'docblockr:decorate-multiline', function (event) {
-    self.event = event;
-    // console.log('Decorate Multiline command');
-    if (self.validate_request({ scope: 'comment.block' })) { self.decorate_multiline_command(); }
-  });
-}
+  update_config () {
+    const settings = global.atom.config.get('docblockr');
+    this.editor_settings = settings;
+  }
 
-DocBlockrAtom.prototype.update_config = function () {
-  const settings = global.atom.config.get('docblockr');
-  this.editor_settings = settings;
-};
-
-/**
-   * Validate the keypress request
-   * @param  {Boolean}  preceding        Check against regex if true
-   * @param  {Regex}    precedingRegex  Regex to check preceding text against
-   * @param  {Boolean}  following        Check against regex if true
-   * @param  {Regex}    followingRegex  Regex to check following text against
-   * @param  {String}   scope            Check if cursor matches scope
-   */
-DocBlockrAtom.prototype.validate_request = function (options) {
   /**
-     *  Multiple cursor behaviour:
-     *   1. Add mulitple snippets dependent on cursor pos, this makes traversing
-     *        snippets not possible
-     *   2. So we will iterate over the cursors and find the first among the cursors
-     *        that satisfies the regex, the rest of the cursors will be deleted.
+     * Validate the keypress request
+     * @param  {Boolean}  preceding        Check against regex if true
+     * @param  {Regex}    precedingRegex  Regex to check preceding text against
+     * @param  {Boolean}  following        Check against regex if true
+     * @param  {Regex}    followingRegex  Regex to check following text against
+     * @param  {String}   scope            Check if cursor matches scope
      */
+  validate_request (options) {
+    /**
+       *  Multiple cursor behaviour:
+       *   1. Add mulitple snippets dependent on cursor pos, this makes traversing
+       *        snippets not possible
+       *   2. So we will iterate over the cursors and find the first among the cursors
+       *        that satisfies the regex, the rest of the cursors will be deleted.
+       */
 
-  options = (typeof options !== 'undefined') ? options : {};
+    options = (typeof options !== 'undefined') ? options : {};
 
-  const preceding = (typeof options.preceding !== 'undefined') ? options.preceding : false;
-  const precedingRegex = (typeof options.precedingRegex !== 'undefined') ? options.precedingRegex : '';
-  const following = (typeof options.following !== 'undefined') ? options.following : false;
-  const followingRegex = (typeof options.followingRegex !== 'undefined') ? options.followingRegex : '';
-  const scope = (typeof options.scope !== 'undefined') ? options.scope : false;
+    const preceding = (typeof options.preceding !== 'undefined') ? options.preceding : false;
+    const precedingRegex = (typeof options.precedingRegex !== 'undefined') ? options.precedingRegex : '';
+    const following = (typeof options.following !== 'undefined') ? options.following : false;
+    const followingRegex = (typeof options.followingRegex !== 'undefined') ? options.followingRegex : '';
+    const scope = (typeof options.scope !== 'undefined') ? options.scope : false;
 
-  const editor = this.get_relevant_editor(this.event);
-  this.cursors = [];
-  let i, len, followingText, precedingText;
+    const editor = this.get_relevant_editor(this.event);
+    this.cursors = [];
+    let i, len, followingText, precedingText;
 
-  const cursorPositions = editor.getCursors();
+    const cursorPositions = editor.getCursors();
 
-  for (i = 0, len = cursorPositions.length; i < len; i++) {
-    const cursorPosition = cursorPositions[i].getBufferPosition();
+    for (i = 0, len = cursorPositions.length; i < len; i++) {
+      const cursorPosition = cursorPositions[i].getBufferPosition();
 
-    if (scope) {
-      const scopeList = editor.scopeDescriptorForBufferPosition(cursorPosition).getScopesArray();
-      let _i, _len;
-      for (_i = 0; _i < (_len = scopeList.length); _i++) {
-        if (scopeList[_i].search(scope) > -1) {
+      if (scope) {
+        const scopeList = editor.scopeDescriptorForBufferPosition(cursorPosition).getScopesArray();
+        let _i, _len;
+        for (_i = 0; _i < (_len = scopeList.length); _i++) {
+          if (scopeList[_i].search(scope) > -1) {
+            break;
+          }
+        }
+
+        if (_i === _len) {
+          // scope did not succeed
+          continue;
+        }
+      }
+
+      if (preceding) { precedingText = editor.getTextInBufferRange([[cursorPosition.row, 0], cursorPosition]); }
+
+      if (following) {
+        const lineLength = editor.lineTextForBufferRow(cursorPosition.row).length;
+        const followingRange = [cursorPosition, [cursorPosition.row, lineLength]];
+        followingText = editor.getTextInBufferRange(followingRange);
+      }
+
+      if (preceding && following) {
+        if ((precedingText.search(precedingRegex) > -1) && (followingText.search(followingRegex) > -1)) {
+          this.cursors.push(cursorPosition);
           break;
         }
-      }
-
-      if (_i === _len) {
-        // scope did not succeed
-        continue;
+      } else if (preceding) {
+        if (precedingText.search(precedingRegex) > -1) {
+          this.cursors.push(cursorPosition);
+          break;
+        }
+      } else if (following) {
+        if (followingText.search(followingRegex) > -1) {
+          this.cursors.push(cursorPosition);
+          break;
+        }
+      } else if (scope) {
+        /* comes here only if scope is being checked */
+        return true;
       }
     }
 
-    if (preceding) { precedingText = editor.getTextInBufferRange([[cursorPosition.row, 0], cursorPosition]); }
-
-    if (following) {
-      const lineLength = editor.lineTextForBufferRow(cursorPosition.row).length;
-      const followingRange = [cursorPosition, [cursorPosition.row, lineLength]];
-      followingText = editor.getTextInBufferRange(followingRange);
-    }
-
-    if (preceding && following) {
-      if ((precedingText.search(precedingRegex) > -1) && (followingText.search(followingRegex) > -1)) {
-        this.cursors.push(cursorPosition);
-        break;
-      }
-    } else if (preceding) {
-      if (precedingText.search(precedingRegex) > -1) {
-        this.cursors.push(cursorPosition);
-        break;
-      }
-    } else if (following) {
-      if (followingText.search(followingRegex) > -1) {
-        this.cursors.push(cursorPosition);
-        break;
-      }
-    } else if (scope) {
-      /* comes here only if scope is being checked */
+    if (this.cursors.length > 0) {
+      cursorPositions.splice(i, 1);
+      cursorPositions.forEach(function (value) {
+        value.destroy();
+      });
       return true;
-    }
+    } else { return false; }
   }
 
-  if (this.cursors.length > 0) {
-    cursorPositions.splice(i, 1);
-    cursorPositions.forEach(function (value) {
-      value.destroy();
-    });
-    return true;
-  } else { return false; }
-};
-
-DocBlockrAtom.prototype.parse_command = function (inline) {
-  const editor = this.get_relevant_editor();
-  if (typeof editor === 'undefined' || editor === null) {
-    return;
-  }
-  this.initialize(editor, inline);
-  if (this.parser.is_existing_comment(this.line)) {
-    this.write(editor, '\n *' + this.indentSpaces);
-    return;
-  }
-
-  // erase characters in the view (will be added to the output later)
-  this.erase(editor, this.trailing_range);
-
-  // match against a function declaration.
-  const out = this.parser.parse(this.line);
-  let snippet = this.generate_snippet(out, inline);
-  // atom doesnt currently support, snippet end by default
-  // so add $0
-  if ((snippet.search(/\${0:/) < 0) && (snippet.search(/\$0/) < 0)) { snippet += '$0'; }
-  this.write(editor, snippet);
-};
-
-/**
-   * Perform actions for a single-asterix block comment
-   */
-DocBlockrAtom.prototype.parse_block_command = function () {
-  const editor = this.get_relevant_editor();
-  if (typeof editor === 'undefined' || editor === null) {
-    return;
-  }
-  this.initialize(editor, false);
-
-  // Remove trailing characters (will write them appropriately later)
-  this.erase(editor, this.trailing_range);
-
-  // Build the string to write
-  let string = '\n';
-
-  // Might include asterixes
-  if (this.editor_settings.c_style_block_comments) {
-    string += ' *' + this.indentSpaces;
-  }
-
-  // Write indentation and trailing characters. Place cursor before
-  // trailing characters
-
-  string += '$0';
-  string += this.trailing_string;
-
-  // Close if needed
-  if (!this.parser.is_existing_comment(this.line)) {
-    string += '\n */';
-  }
-
-  this.write(editor, string);
-};
-
-DocBlockrAtom.prototype.trim_auto_whitespace_command = function () {
-  /**
-     * Trim the automatic whitespace added when creating a new line in a docblock.
-     */
-  const editor = this.get_relevant_editor();
-  if (typeof editor === 'undefined' || editor === null) {
-    return;
-  }
-  const cursorPosition = editor.getCursorBufferPosition();
-  let lineText = editor.lineTextForBufferRow(cursorPosition.row);
-  const lineLength = editor.lineTextForBufferRow(cursorPosition.row).length;
-  const spaces = Math.max(0, this.editor_settings.indentation_spaces);
-
-  const regex = /^(\s*\*)\s*$/;
-  lineText = lineText.replace(regex, ('$1\n$1' + this.repeat(' ', spaces)));
-  const range = [[cursorPosition.row, 0], [cursorPosition.row, lineLength]];
-  editor.setTextInBufferRange(range, lineText);
-};
-
-DocBlockrAtom.prototype.indent_command = function () {
-  const editor = this.get_relevant_editor();
-  const currentPos = editor.getCursorBufferPosition();
-  const prevLine = editor.lineTextForBufferRow(currentPos.row - 1);
-  const spaces = this.get_indentSpaces(editor, prevLine);
-
-  if (spaces !== null) {
-    const matches = /^(\s*(?:\*|\/\/\/))/.exec(prevLine);
-    const toStar = matches[1].length;
-    const toInsert = spaces - currentPos.column + toStar;
-    if (toInsert <= 0) {
-      if (this.event) {
-        this.event.abortKeyBinding();
-      }
+  parse_command (inline) {
+    const editor = this.get_relevant_editor();
+    if (typeof editor === 'undefined' || editor === null) {
       return;
     }
-    editor.insertText(this.repeat(' ', toInsert));
-  } else if (this.event) {
-    this.event.abortKeyBinding();
-  }
-};
-
-DocBlockrAtom.prototype.join_command = function () {
-  const editor = this.get_relevant_editor();
-  const selections = editor.getSelections();
-  let i, j, rowBegin;
-  const textWithEnding = function (row) {
-    return editor.buffer.lineForRow(row) + editor.buffer.lineEndingForRow(row);
-  };
-
-  for (i = 0; i < selections.length; i++) {
-    const selection = selections[i];
-    let noRows;
-    const _r = selection.getBufferRowRange();
-    noRows = Math.abs(_r[0] - _r[1]); // no of rows in selection
-    rowBegin = Math.min(_r[0], _r[1]);
-    if (noRows === 0) {
-      // exit if current line is the last one
-      if ((_r[0] + 1) === editor.getLastBufferRow()) { continue; }
-      noRows = 2;
-    } else { noRows += 1; }
-
-    let text = '';
-    for (j = 0; j < noRows; j++) {
-      text += textWithEnding(rowBegin + j);
+    this.initialize(editor, inline);
+    if (this.parser.is_existing_comment(this.line)) {
+      this.write(editor, '\n *' + this.indentSpaces);
+      return;
     }
-    const regex = /[ \t]*\n[ \t]*((?:\*|\/\/[!/]?|#)[ \t]*)?/g;
-    text = text.replace(regex, ' ');
-    const endLineLength = editor.lineTextForBufferRow(rowBegin + noRows - 1).length;
-    const range = [[rowBegin, 0], [rowBegin + noRows - 1, endLineLength]];
-    editor.setTextInBufferRange(range, text);
-  }
-};
 
-DocBlockrAtom.prototype.decorate_command = function () {
-  const editor = this.get_relevant_editor();
-  const pos = editor.getCursorBufferPosition();
-  const whitespaceRe = /^(\s*)\/\//;
-  const scopeRange = this.scopeRange(editor, pos, 'comment.line.double-slash');
+    // erase characters in the view (will be added to the output later)
+    this.erase(editor, this.trailing_range);
 
-  let maxLen = 0;
-  let _i, leadingWs, lineText, tabCount;
-  const _row = scopeRange[0].row;
-  const _len = Math.abs(scopeRange[0].row - scopeRange[1].row);
-
-  for (_i = 0; _i <= _len; _i++) {
-    lineText = editor.lineTextForBufferRow(_row + _i);
-    tabCount = lineText.split('\t').length - 1;
-
-    const matches = whitespaceRe.exec(lineText);
-    if (matches[1] == null) { leadingWs = 0; } else { leadingWs = matches[1].length; }
-
-    leadingWs -= tabCount;
-    maxLen = Math.max(maxLen, editor.lineTextForBufferRow(_row + _i).length);
+    // match against a function declaration.
+    const out = this.parser.parse(this.line);
+    let snippet = this.generate_snippet(out, inline);
+    // atom doesnt currently support, snippet end by default
+    // so add $0
+    if ((snippet.search(/\${0:/) < 0) && (snippet.search(/\$0/) < 0)) { snippet += '$0'; }
+    this.write(editor, snippet);
   }
 
-  const lineLength = maxLen - leadingWs;
-  leadingWs = this.repeat('\t', tabCount) + this.repeat(' ', leadingWs);
-  editor.buffer.insert(scopeRange[1], '\n' + leadingWs + this.repeat('/', (lineLength + 3)) + '\n');
-
-  for (_i = _len; _i >= 0; _i--) {
-    lineText = editor.lineTextForBufferRow(_row + _i);
-    const _length = editor.lineTextForBufferRow(_row + _i).length;
-    const rPadding = 1 + (maxLen - _length);
-    const _range = [[scopeRange[0].row + _i, 0], [scopeRange[0].row + _i, _length]];
-    editor.setTextInBufferRange(_range, leadingWs + lineText + this.repeat(' ', rPadding) + '//');
-  }
-  editor.buffer.insert(scopeRange[0], this.repeat('/', lineLength + 3) + '\n');
-};
-
-DocBlockrAtom.prototype.decorate_multiline_command = function () {
-  const editor = this.get_relevant_editor();
-  const pos = editor.getCursorBufferPosition();
-  const whitespaceRe = /^(\s*)\/\*/;
-  const tabSize = global.atom.config.get('editor.tabLength');
-  const scopeRange = this.scopeRange(editor, pos, 'comment.block');
-  const lineLengths = {};
-
-  let maxLen = 0;
-  let _i, blockWs, lineText, contentTabCount;
-  const _row = scopeRange[0].row;
-  const _len = Math.abs(scopeRange[0].row - scopeRange[1].row);
-
-  // get block indent from first line
-  lineText = editor.lineTextForBufferRow(_row);
-  const blockTabCount = lineText.split('\t').length - 1;
-  const matches = whitespaceRe.exec(lineText);
-  if (matches == null) { blockWs = 0; } else { blockWs = matches[1].length; }
-  blockWs -= blockTabCount;
-
-  // get maxLen
-  for (_i = 1; _i < _len; _i++) {
-    lineText = editor.lineTextForBufferRow(_row + _i);
-    const textLength = lineText.length;
-    contentTabCount = lineText.split('\t').length - 1;
-    lineLengths[_i] = textLength - contentTabCount + (contentTabCount * tabSize);
-    maxLen = Math.max(maxLen, lineLengths[_i]);
-  }
-
-  const lineLength = maxLen - blockWs;
-  blockWs = this.repeat('\t', blockTabCount) + this.repeat(' ', blockWs);
-
-  // last line
-  lineText = editor.lineTextForBufferRow(scopeRange[1].row);
-  lineText = lineText.replace(/^(\s*)(\*)+\//, (function (self) {
-    return function (match, p1, stars) {
-      const len = stars.length;
-      return (p1 + self.repeat('*', (lineLength + 2 - len)) + '/' + '\n');
-    };
-  }(this)));
-  let _range = [[scopeRange[1].row, 0], [scopeRange[1].row, lineLength]];
-  editor.setTextInBufferRange(_range, lineText);
-
-  // first line
-  lineText = editor.lineTextForBufferRow(scopeRange[0].row);
-  lineText = lineText.replace(/^(\s*)\/(\*)+/, (function (self) {
-    return function (match, p1, stars) {
-      const len = stars.length;
-      return (p1 + '/' + self.repeat('*', (lineLength + 2 - len)));
-    };
-  }(this)));
-  _range = [[scopeRange[0].row, 0], [scopeRange[0].row, lineLength]];
-  editor.setTextInBufferRange(_range, lineText);
-
-  // skip first line and last line
-  for (_i = _len - 1; _i > 0; _i--) {
-    lineText = editor.lineTextForBufferRow(_row + _i);
-    const _length = editor.lineTextForBufferRow(_row + _i).length;
-    const rPadding = 1 + (maxLen - lineLengths[_i]);
-    _range = [[scopeRange[0].row + _i, 0], [scopeRange[0].row + _i, _length]];
-    editor.setTextInBufferRange(_range, lineText + this.repeat(' ', rPadding) + '*');
-  }
-};
-
-DocBlockrAtom.prototype.deindent_command = function () {
-  /*
-     * When pressing enter at the end of a docblock, this takes the cursor back one space.
-    /**
-     *
-     *//* |   <-- from here
-    |      <-- to here
-     */
-  const editor = this.get_relevant_editor();
-  const cursor = editor.getCursorBufferPosition();
-  let text = editor.lineTextForBufferRow(cursor.row);
-  text = text.replace(/^(\s*)\s\*\/.*/, '\n$1');
-  editor.insertText(text, { autoIndentNewline: false });
-};
-
-DocBlockrAtom.prototype.reparse_command = function () {
-  // Reparse a docblock to make the fields 'active' again, so that pressing tab will jump to the next one
-  const tabIndex = this.counter();
-  const tabStop = function (m, g1) {
-    return `\${${tabIndex()}:${g1}}`;
-  };
-  const editor = this.get_relevant_editor();
-  const pos = editor.getCursorBufferPosition();
-  // const Snippets = global.atom.packages.activePackages.snippets.mainModule;
-  // disable all snippet expansions
-
-  if (editor.snippetExpansion != null) { editor.snippetExpansion.destroy(); }
-  const scopeRange = this.scopeRange(editor, pos, 'comment.block');
-  let text = editor.getTextInBufferRange([scopeRange[0], scopeRange[1]]);
-  // escape string, so variables starting with $ won't be removed
-  text = escape(text);
-  // strip out leading spaces, since inserting a snippet keeps the indentation
-  text = text.replace(/\n\s+\*/g, '\n *');
-  // replace [bracketed] [text] with a tabstop
-  text = text.replace(/(\[.+?\])/g, tabStop);
-
-  editor.buffer.delete(([scopeRange[0], scopeRange[1]]));
-  editor.setCursorBufferPosition(scopeRange[0]);
-  if ((text.search(/\${0:/) < 0) && (text.search(/\$0/) < 0)) { text += '$0'; }
-  this.write(editor, text);
-};
-
-DocBlockrAtom.prototype.wrap_lines_command = function () {
   /**
-     * Reformat description text inside a comment block to wrap at the correct length.
-     *  Wrap column is set by the first ruler (set in Default.sublime-settings), or 80 by default.
-     * Shortcut Key: alt+q
+     * Perform actions for a single-asterix block comment
      */
-  const editor = this.get_relevant_editor();
-  const pos = editor.getCursorBufferPosition();
-  // const tabSize = global.atom.config.get('editor.tabLength');
-  const wrapLen = global.atom.config.get('editor.preferredLineLength');
+  parse_block_command () {
+    const editor = this.get_relevant_editor();
+    if (typeof editor === 'undefined' || editor === null) {
+      return;
+    }
+    this.initialize(editor, false);
 
-  const numIndentSpaces = Math.max(0, (this.editor_settings.indentation_spaces ? this.editor_settings.indentation_spaces : 1));
-  const indentSpaces = this.repeat(' ', numIndentSpaces);
-  const indentSpacesSamePara = this.repeat(' ', (this.editor_settings.indentation_spaces_same_para ? this.editor_settings.indentation_spaces_same_para : numIndentSpaces));
-  const spacerBetweenSections = (this.editor_settings.spacerBetweenSections === 'true');
-  const spacerBetweenDescTags = (this.editor_settings.spacerBetweenSections !== 'false');
+    // Remove trailing characters (will write them appropriately later)
+    this.erase(editor, this.trailing_range);
 
-  const scopeRange = this.scopeRange(editor, pos, 'comment.block');
-  // const text = editor.getTextInBufferRange([scopeRange[0], scopeRange[1]]);
+    // Build the string to write
+    let string = '\n';
 
-  // find the first word
-  let i, len, _col, _text;
-  const startPoint = {};
-  const endPoint = {};
-  const startRow = scopeRange[0].row;
-  len = Math.abs(scopeRange[0].row - scopeRange[1].row);
-  for (i = 0; i <= len; i++) {
-    _text = editor.lineTextForBufferRow(startRow + i);
-    _col = _text.search(/^\s*\* /);
-    if (_col > -1) {
-      if (i === 0) {
-        startPoint.column = scopeRange[0].column + _col;
-      } else {
-        startPoint.column = _col;
+    // Might include asterixes
+    if (this.editor_settings.c_style_block_comments) {
+      string += ' *' + this.indentSpaces;
+    }
+
+    // Write indentation and trailing characters. Place cursor before
+    // trailing characters
+
+    string += '$0';
+    string += this.trailing_string;
+
+    // Close if needed
+    if (!this.parser.is_existing_comment(this.line)) {
+      string += '\n */';
+    }
+
+    this.write(editor, string);
+  }
+
+  trim_auto_whitespace_command () {
+    /**
+       * Trim the automatic whitespace added when creating a new line in a docblock.
+       */
+    const editor = this.get_relevant_editor();
+    if (typeof editor === 'undefined' || editor === null) {
+      return;
+    }
+    const cursorPosition = editor.getCursorBufferPosition();
+    let lineText = editor.lineTextForBufferRow(cursorPosition.row);
+    const lineLength = editor.lineTextForBufferRow(cursorPosition.row).length;
+    const spaces = Math.max(0, this.editor_settings.indentation_spaces);
+
+    const regex = /^(\s*\*)\s*$/;
+    lineText = lineText.replace(regex, ('$1\n$1' + this.repeat(' ', spaces)));
+    const range = [[cursorPosition.row, 0], [cursorPosition.row, lineLength]];
+    editor.setTextInBufferRange(range, lineText);
+  }
+
+  indent_command () {
+    const editor = this.get_relevant_editor();
+    const currentPos = editor.getCursorBufferPosition();
+    const prevLine = editor.lineTextForBufferRow(currentPos.row - 1);
+    const spaces = this.get_indentSpaces(editor, prevLine);
+
+    if (spaces !== null) {
+      const matches = /^(\s*(?:\*|\/\/\/))/.exec(prevLine);
+      const toStar = matches[1].length;
+      const toInsert = spaces - currentPos.column + toStar;
+      if (toInsert <= 0) {
+        if (this.event) {
+          this.event.abortKeyBinding();
+        }
+        return;
       }
-      startPoint.row = scopeRange[0].row + i;
-      break;
+      editor.insertText(this.repeat(' ', toInsert));
+    } else if (this.event) {
+      this.event.abortKeyBinding();
     }
   }
-  // find the first tag, or the end of the comment
-  for (i = 0; i <= len; i++) {
-    _text = editor.lineTextForBufferRow(startRow + i);
-    _col = _text.search(/^\s*\*(\/)/);
-    if (_col > -1) {
-      if (i === 0) {
-        endPoint.column = scopeRange[0].column + _col;
-      } else {
-        endPoint.column = _col;
-      }
-      endPoint.row = scopeRange[0].row + i;
-      break;
-    }
-  }
-  let text = editor.getTextInBufferRange([startPoint, endPoint]);
 
-  // find the indentation level
-  const regex = /(\s*\*)/;
-  const matches = regex.exec(text);
-  // const indentation = matches[1].replace(/\t/g, this.repeat(' ', tabSize)).length;
-  const linePrefix = matches[1];
-
-  // join all the lines, collapsing "empty" lines
-  text = text.replace(/\n(\s*\*\s*\n)+/g, '\n\n');
-
-  const wrapPara = function (para) {
-    para = para.replace(/(\n|^)\s*\*\s*/g, ' ');
-    let _i;
-    // split the paragraph into words
-    const words = para.trim().split(' ');
-    let text = '\n';
-    let line = linePrefix + indentSpaces;
-    let lineTagged = false; // indicates if the line contains a doc tag
-    let paraTagged = false; // indicates if this paragraph contains a doc tag
-    let lineIsNew = true;
-    let tag = '';
-    // join all words to create lines, no longer than wrapLength
-    for (_i = 0; _i < words.length; _i++) {
-      const word = words[_i];
-      if ((word == null) && (!lineTagged)) { continue; }
-
-      if ((lineIsNew) && (word[0] === '@')) {
-        lineTagged = true;
-        paraTagged = true;
-        tag = word;
-      }
-
-      if ((line.length + word.length) > wrapLen) {
-        // appending the word to the current line would exceed its
-        // length requirements
-        text += line.replace(/\s+$/, '') + '\n';
-        line = linePrefix + indentSpacesSamePara + word + ' ';
-        lineTagged = false;
-        lineIsNew = true;
-      } else {
-        line += word + ' ';
-      }
-      lineIsNew = false;
-    }
-    text += line.replace(/\s+$/, '');
-
-    return {
-      text: text,
-      lineTagged: lineTagged,
-      tagged: paraTagged,
-      tag: tag
+  join_command () {
+    const editor = this.get_relevant_editor();
+    const selections = editor.getSelections();
+    let i, j, rowBegin;
+    const textWithEnding = function (row) {
+      return editor.buffer.lineForRow(row) + editor.buffer.lineEndingForRow(row);
     };
-  };
 
-  // split the text into paragraphs, where each paragraph is eighter
-  // defined by an empty line or the start of a doc parameter
-  const paragraphs = text.split(/\n{2,}|\n\s*\*\s*(?=@)/);
-  const wrappedParas = [];
-  text = '';
-  for (i = 0; i < paragraphs.length; i++) {
-    // wrap the lines in the current paragraph
-    wrappedParas.push(wrapPara(paragraphs[i]));
-  }
+    for (i = 0; i < selections.length; i++) {
+      const selection = selections[i];
+      let noRows;
+      const _r = selection.getBufferRowRange();
+      noRows = Math.abs(_r[0] - _r[1]); // no of rows in selection
+      rowBegin = Math.min(_r[0], _r[1]);
+      if (noRows === 0) {
+        // exit if current line is the last one
+        if ((_r[0] + 1) === editor.getLastBufferRow()) { continue; }
+        noRows = 2;
+      } else { noRows += 1; }
 
-  // combine all the paragraphs into a single piece of text
-  for (i = 0; i < (len = wrappedParas.length); i++) {
-    const para = wrappedParas[i];
-    const last = (i === (wrappedParas.length - 1));
-    let _tag, _tagged;
-    if (i === len - 1) {
-      _tag = _tagged = false;
-    } else {
-      _tag = wrappedParas[i + 1].tag;
-      _tagged = wrappedParas[i + 1].tagged;
-    }
-    const nextIsTagged = (!last && _tagged);
-    const nextIsSameTag = ((nextIsTagged && para.tag) === _tag);
-
-    if (last || ((para.lineTagged || nextIsTagged) && !(spacerBetweenSections && (!nextIsSameTag)) && !((!para.lineTagged) && nextIsTagged && spacerBetweenDescTags))) {
-      text += para.text;
-    } else {
-      text += para.text + '\n' + linePrefix;
+      let text = '';
+      for (j = 0; j < noRows; j++) {
+        text += textWithEnding(rowBegin + j);
+      }
+      const regex = /[ \t]*\n[ \t]*((?:\*|\/\/[!/]?|#)[ \t]*)?/g;
+      text = text.replace(regex, ' ');
+      const endLineLength = editor.lineTextForBufferRow(rowBegin + noRows - 1).length;
+      const range = [[rowBegin, 0], [rowBegin + noRows - 1, endLineLength]];
+      editor.setTextInBufferRange(range, text);
     }
   }
-  text = escape(text);
-  // strip start \n
-  if (text.search(/^\n/) > -1) { text = text.replace(/^\n/, ''); }
-  // add end \n
-  if (text.search(/\n$/) < 0) { text += '\n'; }
-  editor.setTextInBufferRange([startPoint, endPoint], text);
-};
 
-DocBlockrAtom.prototype.get_indentSpaces = function (editor, line) {
-  const hasTypes = this.get_parser(editor).settings.typeInfo;
-  const extraIndent = ((hasTypes === true) ? '\\s+\\S+' : '');
+  decorate_command () {
+    const editor = this.get_relevant_editor();
+    const pos = editor.getCursorBufferPosition();
+    const whitespaceRe = /^(\s*)\/\//;
+    const scopeRange = this.scopeRange(editor, pos, 'comment.line.double-slash');
 
-  const regex = [
-    new RegExp(util.format('^\\s*(\\*|\\/\\/\\/)(\\s*@(?:param|property)%s\\s+\\S+\\s+)\\S', extraIndent)),
-    new RegExp(util.format('^\\s*(\\*|\\/\\/\\/)(\\s*@(?:returns?|define)%s\\s+\\S+\\s+)\\S', extraIndent)),
-    new RegExp('^\\s*(\\*|\\/\\/\\/)(\\s*@[a-z]+\\s+)\\S'),
-    new RegExp('^\\s*(\\*|\\/\\/\\/)(\\s*)')
-  ];
+    let maxLen = 0;
+    let _i, leadingWs, lineText, tabCount;
+    const _row = scopeRange[0].row;
+    const _len = Math.abs(scopeRange[0].row - scopeRange[1].row);
 
-  let i, matches;
-  for (i = 0; i < regex.length; i++) {
-    matches = regex[i].exec(line);
-    if (matches != null) { return matches[1].length; }
+    for (_i = 0; _i <= _len; _i++) {
+      lineText = editor.lineTextForBufferRow(_row + _i);
+      tabCount = lineText.split('\t').length - 1;
+
+      const matches = whitespaceRe.exec(lineText);
+      if (matches[1] == null) { leadingWs = 0; } else { leadingWs = matches[1].length; }
+
+      leadingWs -= tabCount;
+      maxLen = Math.max(maxLen, editor.lineTextForBufferRow(_row + _i).length);
+    }
+
+    const lineLength = maxLen - leadingWs;
+    leadingWs = this.repeat('\t', tabCount) + this.repeat(' ', leadingWs);
+    editor.buffer.insert(scopeRange[1], '\n' + leadingWs + this.repeat('/', (lineLength + 3)) + '\n');
+
+    for (_i = _len; _i >= 0; _i--) {
+      lineText = editor.lineTextForBufferRow(_row + _i);
+      const _length = editor.lineTextForBufferRow(_row + _i).length;
+      const rPadding = 1 + (maxLen - _length);
+      const _range = [[scopeRange[0].row + _i, 0], [scopeRange[0].row + _i, _length]];
+      editor.setTextInBufferRange(_range, leadingWs + lineText + this.repeat(' ', rPadding) + '//');
+    }
+    editor.buffer.insert(scopeRange[0], this.repeat('/', lineLength + 3) + '\n');
   }
-  return null;
-};
 
-DocBlockrAtom.prototype.initialize = function (editor, inline) {
-  inline = (typeof inline === 'undefined') ? false : inline;
-  let cursorPosition = editor.getCursorBufferPosition(); // will handle only one instance
-  // Get trailing string
-  const lineLength = editor.lineTextForBufferRow(cursorPosition.row).length;
-  this.trailing_range = [cursorPosition, [cursorPosition.row, lineLength]];
-  this.trailing_string = editor.getTextInBufferRange(this.trailing_range);
-  // drop trailing */
-  this.trailing_string = this.trailing_string.replace(/\s*\*\/\s*$/, '');
-  this.trailing_string = escape(this.trailing_string);
+  decorate_multiline_command () {
+    const editor = this.get_relevant_editor();
+    const pos = editor.getCursorBufferPosition();
+    const whitespaceRe = /^(\s*)\/\*/;
+    const tabSize = global.atom.config.get('editor.tabLength');
+    const scopeRange = this.scopeRange(editor, pos, 'comment.block');
+    const lineLengths = {};
 
-  this.parser = this.get_parser(editor);
-  this.parser.inline = inline;
+    let maxLen = 0;
+    let _i, blockWs, lineText, contentTabCount;
+    const _row = scopeRange[0].row;
+    const _len = Math.abs(scopeRange[0].row - scopeRange[1].row);
 
-  this.indentSpaces = this.repeat(' ', Math.max(0, (this.editor_settings.indentation_spaces || 1)));
-  this.prefix = this.get_parser(editor).settings.prefix || ' *';
+    // get block indent from first line
+    lineText = editor.lineTextForBufferRow(_row);
+    const blockTabCount = lineText.split('\t').length - 1;
+    const matches = whitespaceRe.exec(lineText);
+    if (matches == null) { blockWs = 0; } else { blockWs = matches[1].length; }
+    blockWs -= blockTabCount;
 
-  const settingsAlignTags = this.editor_settings.align_tags || 'deep';
-  this.deepAlignTags = settingsAlignTags === 'deep';
-  this.shallowAlignTags = ((settingsAlignTags === 'shallow') || (settingsAlignTags === true));
+    // get maxLen
+    for (_i = 1; _i < _len; _i++) {
+      lineText = editor.lineTextForBufferRow(_row + _i);
+      const textLength = lineText.length;
+      contentTabCount = lineText.split('\t').length - 1;
+      lineLengths[_i] = textLength - contentTabCount + (contentTabCount * tabSize);
+      maxLen = Math.max(maxLen, lineLengths[_i]);
+    }
 
-  // use trailing string as a description of the function
-  if (this.trailingString) { this.parser.setNameOverride(this.trailingString); }
+    const lineLength = maxLen - blockWs;
+    blockWs = this.repeat('\t', blockTabCount) + this.repeat(' ', blockWs);
 
-  // read the next line
-  cursorPosition = cursorPosition.copy();
-  cursorPosition.row += 1;
-  this.line = this.parser.get_definition(editor, cursorPosition, this.read_line);
-};
+    // last line
+    lineText = editor.lineTextForBufferRow(scopeRange[1].row);
+    lineText = lineText.replace(/^(\s*)(\*)+\//, (function (self) {
+      return function (match, p1, stars) {
+        const len = stars.length;
+        return (p1 + self.repeat('*', (lineLength + 2 - len)) + '/' + '\n');
+      };
+    }(this)));
+    let _range = [[scopeRange[1].row, 0], [scopeRange[1].row, lineLength]];
+    editor.setTextInBufferRange(_range, lineText);
 
-DocBlockrAtom.prototype.set_snippets_service = function (service) {
-  this.snippets_service = service;
-};
+    // first line
+    lineText = editor.lineTextForBufferRow(scopeRange[0].row);
+    lineText = lineText.replace(/^(\s*)\/(\*)+/, (function (self) {
+      return function (match, p1, stars) {
+        const len = stars.length;
+        return (p1 + '/' + self.repeat('*', (lineLength + 2 - len)));
+      };
+    }(this)));
+    _range = [[scopeRange[0].row, 0], [scopeRange[0].row, lineLength]];
+    editor.setTextInBufferRange(_range, lineText);
 
-DocBlockrAtom.prototype.counter = function () {
-  let count = 0;
-  return function () {
-    return ++count;
-  };
-};
-
-DocBlockrAtom.prototype.repeat = function (string, number) {
-  return Array(Math.max(0, number) + 1).join(string);
-};
-
-DocBlockrAtom.prototype.write = function (editor, str) {
-  // will insert data at last cursor position
-  if (this.snippets_service) { this.snippets_service.insertSnippet(str, editor); } else {
-    global.atom.notifications.addFatalError('Docblockr: Snippets package disabled.', {
-      detail: 'Please enable Snippets package for Docblockr to function properly.',
-      dismissable: true,
-      icon: 'flame'
-    });
-    if (this.event) { this.event.abortKeyBinding(); }
+    // skip first line and last line
+    for (_i = _len - 1; _i > 0; _i--) {
+      lineText = editor.lineTextForBufferRow(_row + _i);
+      const _length = editor.lineTextForBufferRow(_row + _i).length;
+      const rPadding = 1 + (maxLen - lineLengths[_i]);
+      _range = [[scopeRange[0].row + _i, 0], [scopeRange[0].row + _i, _length]];
+      editor.setTextInBufferRange(_range, lineText + this.repeat(' ', rPadding) + '*');
+    }
   }
-};
 
-DocBlockrAtom.prototype.erase = function (editor, range) {
-  const buffer = editor.getBuffer();
-  buffer.delete(range);
-};
-
-DocBlockrAtom.prototype.fill_array = function (len) {
-  const a = [];
-  let i = 0;
-  while (i < len) {
-    a[i] = 0;
-    i++;
+  deindent_command () {
+    /*
+       * When pressing enter at the end of a docblock, this takes the cursor back one space.
+      /**
+       *
+       *//* |   <-- from here
+      |      <-- to here
+       */
+    const editor = this.get_relevant_editor();
+    const cursor = editor.getCursorBufferPosition();
+    let text = editor.lineTextForBufferRow(cursor.row);
+    text = text.replace(/^(\s*)\s\*\/.*/, '\n$1');
+    editor.insertText(text, { autoIndentNewline: false });
   }
-  return a;
-};
 
-DocBlockrAtom.prototype.get_relevant_editor = function () {
-  let atomTextEditor;
-  if (this.event && this.event.target) {
-    atomTextEditor = this.event.target.closest('atom-text-editor');
-    if (atomTextEditor) { return atomTextEditor.getModel(); }
+  reparse_command () {
+    // Reparse a docblock to make the fields 'active' again, so that pressing tab will jump to the next one
+    const tabIndex = this.counter();
+    const tabStop = function (m, g1) {
+      return `\${${tabIndex()}:${g1}}`;
+    };
+    const editor = this.get_relevant_editor();
+    const pos = editor.getCursorBufferPosition();
+    // const Snippets = global.atom.packages.activePackages.snippets.mainModule;
+    // disable all snippet expansions
+
+    if (editor.snippetExpansion != null) { editor.snippetExpansion.destroy(); }
+    const scopeRange = this.scopeRange(editor, pos, 'comment.block');
+    let text = editor.getTextInBufferRange([scopeRange[0], scopeRange[1]]);
+    // escape string, so variables starting with $ won't be removed
+    text = escape(text);
+    // strip out leading spaces, since inserting a snippet keeps the indentation
+    text = text.replace(/\n\s+\*/g, '\n *');
+    // replace [bracketed] [text] with a tabstop
+    text = text.replace(/(\[.+?\])/g, tabStop);
+
+    editor.buffer.delete(([scopeRange[0], scopeRange[1]]));
+    editor.setCursorBufferPosition(scopeRange[0]);
+    if ((text.search(/\${0:/) < 0) && (text.search(/\$0/) < 0)) { text += '$0'; }
+    this.write(editor, text);
   }
-  const editor = global.atom.workspace.getActiveTextEditor();
-  if (editor !== undefined) { return editor; }
-  return null;
-};
 
-DocBlockrAtom.prototype.read_line = function (editor, point) {
-  // TODO: no longer works
-  if (point >= editor.getText().length) { return; }
-  return editor.lineTextForBufferRow(point.row);
-};
+  wrap_lines_command () {
+    /**
+       * Reformat description text inside a comment block to wrap at the correct length.
+       *  Wrap column is set by the first ruler (set in Default.sublime-settings), or 80 by default.
+       * Shortcut Key: alt+q
+       */
+    const editor = this.get_relevant_editor();
+    const pos = editor.getCursorBufferPosition();
+    // const tabSize = global.atom.config.get('editor.tabLength');
+    const wrapLen = global.atom.config.get('editor.preferredLineLength');
 
-DocBlockrAtom.prototype.scopeRange = function (editor, point, scopeName) {
-  // find scope starting point
-  // checks: ends when row less than zero, column != 0
-  // check if current point is valid
-  let _range;
-  if ((_range = editor.bufferRangeForScopeAtPosition(scopeName, point)) == null) { return null; }
+    const numIndentSpaces = Math.max(0, (this.editor_settings.indentation_spaces ? this.editor_settings.indentation_spaces : 1));
+    const indentSpaces = this.repeat(' ', numIndentSpaces);
+    const indentSpacesSamePara = this.repeat(' ', (this.editor_settings.indentation_spaces_same_para ? this.editor_settings.indentation_spaces_same_para : numIndentSpaces));
+    const spacerBetweenSections = (this.editor_settings.spacerBetweenSections === 'true');
+    const spacerBetweenDescTags = (this.editor_settings.spacerBetweenSections !== 'false');
 
-  let start, end;
-  let _row = point.row;
-  let lineLength;
-  start = _range.start;
-  end = _range.end;
-  while (_row >= 0) {
-    lineLength = editor.lineTextForBufferRow(_row).length;
-    _range = editor.bufferRangeForScopeAtPosition(scopeName, [_row, lineLength]);
-    if (_range == null) { break; }
+    const scopeRange = this.scopeRange(editor, pos, 'comment.block');
+    // const text = editor.getTextInBufferRange([scopeRange[0], scopeRange[1]]);
+
+    // find the first word
+    let i, len, _col, _text;
+    const startPoint = {};
+    const endPoint = {};
+    const startRow = scopeRange[0].row;
+    len = Math.abs(scopeRange[0].row - scopeRange[1].row);
+    for (i = 0; i <= len; i++) {
+      _text = editor.lineTextForBufferRow(startRow + i);
+      _col = _text.search(/^\s*\* /);
+      if (_col > -1) {
+        if (i === 0) {
+          startPoint.column = scopeRange[0].column + _col;
+        } else {
+          startPoint.column = _col;
+        }
+        startPoint.row = scopeRange[0].row + i;
+        break;
+      }
+    }
+    // find the first tag, or the end of the comment
+    for (i = 0; i <= len; i++) {
+      _text = editor.lineTextForBufferRow(startRow + i);
+      _col = _text.search(/^\s*\*(\/)/);
+      if (_col > -1) {
+        if (i === 0) {
+          endPoint.column = scopeRange[0].column + _col;
+        } else {
+          endPoint.column = _col;
+        }
+        endPoint.row = scopeRange[0].row + i;
+        break;
+      }
+    }
+    let text = editor.getTextInBufferRange([startPoint, endPoint]);
+
+    // find the indentation level
+    const regex = /(\s*\*)/;
+    const matches = regex.exec(text);
+    // const indentation = matches[1].replace(/\t/g, this.repeat(' ', tabSize)).length;
+    const linePrefix = matches[1];
+
+    // join all the lines, collapsing "empty" lines
+    text = text.replace(/\n(\s*\*\s*\n)+/g, '\n\n');
+
+    const wrapPara = function (para) {
+      para = para.replace(/(\n|^)\s*\*\s*/g, ' ');
+      let _i;
+      // split the paragraph into words
+      const words = para.trim().split(' ');
+      let text = '\n';
+      let line = linePrefix + indentSpaces;
+      let lineTagged = false; // indicates if the line contains a doc tag
+      let paraTagged = false; // indicates if this paragraph contains a doc tag
+      let lineIsNew = true;
+      let tag = '';
+      // join all words to create lines, no longer than wrapLength
+      for (_i = 0; _i < words.length; _i++) {
+        const word = words[_i];
+        if ((word == null) && (!lineTagged)) { continue; }
+
+        if ((lineIsNew) && (word[0] === '@')) {
+          lineTagged = true;
+          paraTagged = true;
+          tag = word;
+        }
+
+        if ((line.length + word.length) > wrapLen) {
+          // appending the word to the current line would exceed its
+          // length requirements
+          text += line.replace(/\s+$/, '') + '\n';
+          line = linePrefix + indentSpacesSamePara + word + ' ';
+          lineTagged = false;
+          lineIsNew = true;
+        } else {
+          line += word + ' ';
+        }
+        lineIsNew = false;
+      }
+      text += line.replace(/\s+$/, '');
+
+      return {
+        text: text,
+        lineTagged: lineTagged,
+        tagged: paraTagged,
+        tag: tag
+      };
+    };
+
+    // split the text into paragraphs, where each paragraph is eighter
+    // defined by an empty line or the start of a doc parameter
+    const paragraphs = text.split(/\n{2,}|\n\s*\*\s*(?=@)/);
+    const wrappedParas = [];
+    text = '';
+    for (i = 0; i < paragraphs.length; i++) {
+      // wrap the lines in the current paragraph
+      wrappedParas.push(wrapPara(paragraphs[i]));
+    }
+
+    // combine all the paragraphs into a single piece of text
+    for (i = 0; i < (len = wrappedParas.length); i++) {
+      const para = wrappedParas[i];
+      const last = (i === (wrappedParas.length - 1));
+      let _tag, _tagged;
+      if (i === len - 1) {
+        _tag = _tagged = false;
+      } else {
+        _tag = wrappedParas[i + 1].tag;
+        _tagged = wrappedParas[i + 1].tagged;
+      }
+      const nextIsTagged = (!last && _tagged);
+      const nextIsSameTag = ((nextIsTagged && para.tag) === _tag);
+
+      if (last || ((para.lineTagged || nextIsTagged) && !(spacerBetweenSections && (!nextIsSameTag)) && !((!para.lineTagged) && nextIsTagged && spacerBetweenDescTags))) {
+        text += para.text;
+      } else {
+        text += para.text + '\n' + linePrefix;
+      }
+    }
+    text = escape(text);
+    // strip start \n
+    if (text.search(/^\n/) > -1) { text = text.replace(/^\n/, ''); }
+    // add end \n
+    if (text.search(/\n$/) < 0) { text += '\n'; }
+    editor.setTextInBufferRange([startPoint, endPoint], text);
+  }
+
+  get_indentSpaces (editor, line) {
+    const hasTypes = this.get_parser(editor).settings.typeInfo;
+    const extraIndent = ((hasTypes === true) ? '\\s+\\S+' : '');
+
+    const regex = [
+      new RegExp(util.format('^\\s*(\\*|\\/\\/\\/)(\\s*@(?:param|property)%s\\s+\\S+\\s+)\\S', extraIndent)),
+      new RegExp(util.format('^\\s*(\\*|\\/\\/\\/)(\\s*@(?:returns?|define)%s\\s+\\S+\\s+)\\S', extraIndent)),
+      new RegExp('^\\s*(\\*|\\/\\/\\/)(\\s*@[a-z]+\\s+)\\S'),
+      new RegExp('^\\s*(\\*|\\/\\/\\/)(\\s*)')
+    ];
+
+    let i, matches;
+    for (i = 0; i < regex.length; i++) {
+      matches = regex[i].exec(line);
+      if (matches != null) { return matches[1].length; }
+    }
+    return null;
+  }
+
+  initialize (editor, inline) {
+    inline = (typeof inline === 'undefined') ? false : inline;
+    let cursorPosition = editor.getCursorBufferPosition(); // will handle only one instance
+    // Get trailing string
+    const lineLength = editor.lineTextForBufferRow(cursorPosition.row).length;
+    this.trailing_range = [cursorPosition, [cursorPosition.row, lineLength]];
+    this.trailing_string = editor.getTextInBufferRange(this.trailing_range);
+    // drop trailing */
+    this.trailing_string = this.trailing_string.replace(/\s*\*\/\s*$/, '');
+    this.trailing_string = escape(this.trailing_string);
+
+    this.parser = this.get_parser(editor);
+    this.parser.inline = inline;
+
+    this.indentSpaces = this.repeat(' ', Math.max(0, (this.editor_settings.indentation_spaces || 1)));
+    this.prefix = this.get_parser(editor).settings.prefix || ' *';
+
+    const settingsAlignTags = this.editor_settings.align_tags || 'deep';
+    this.deepAlignTags = settingsAlignTags === 'deep';
+    this.shallowAlignTags = ((settingsAlignTags === 'shallow') || (settingsAlignTags === true));
+
+    // use trailing string as a description of the function
+    if (this.trailingString) { this.parser.setNameOverride(this.trailingString); }
+
+    // read the next line
+    cursorPosition = cursorPosition.copy();
+    cursorPosition.row += 1;
+    this.line = this.parser.get_definition(editor, cursorPosition, this.read_line);
+  }
+
+  set_snippets_service (service) {
+    this.snippets_service = service;
+  }
+
+  counter () {
+    let count = 0;
+    return function () {
+      return ++count;
+    };
+  }
+
+  repeat (string, number) {
+    return Array(Math.max(0, number) + 1).join(string);
+  }
+
+  write (editor, str) {
+    // will insert data at last cursor position
+    if (this.snippets_service) { this.snippets_service.insertSnippet(str, editor); } else {
+      global.atom.notifications.addFatalError('Docblockr: Snippets package disabled.', {
+        detail: 'Please enable Snippets package for Docblockr to function properly.',
+        dismissable: true,
+        icon: 'flame'
+      });
+      if (this.event) { this.event.abortKeyBinding(); }
+    }
+  }
+
+  erase (editor, range) {
+    const buffer = editor.getBuffer();
+    buffer.delete(range);
+  }
+
+  fill_array (len) {
+    const a = [];
+    let i = 0;
+    while (i < len) {
+      a[i] = 0;
+      i++;
+    }
+    return a;
+  }
+
+  get_relevant_editor () {
+    let atomTextEditor;
+    if (this.event && this.event.target) {
+      atomTextEditor = this.event.target.closest('atom-text-editor');
+      if (atomTextEditor) { return atomTextEditor.getModel(); }
+    }
+    const editor = global.atom.workspace.getActiveTextEditor();
+    if (editor !== undefined) { return editor; }
+    return null;
+  }
+
+  read_line (editor, point) {
+    // TODO: no longer works
+    if (point >= editor.getText().length) { return; }
+    return editor.lineTextForBufferRow(point.row);
+  }
+
+  scopeRange (editor, point, scopeName) {
+    // find scope starting point
+    // checks: ends when row less than zero, column != 0
+    // check if current point is valid
+    let _range;
+    if ((_range = editor.bufferRangeForScopeAtPosition(scopeName, point)) == null) { return null; }
+
+    let start, end;
+    let _row = point.row;
+    let lineLength;
     start = _range.start;
-    if (start.column > 0) {
-      break;
-    }
-    _row--;
-  }
-  _row = point.row;
-  const lastRow = editor.getLastBufferRow();
-  while (_row <= lastRow) {
-    lineLength = editor.lineTextForBufferRow(_row).length;
-    _range = editor.bufferRangeForScopeAtPosition(scopeName, [_row, 0]);
-    if (_range == null) { break; }
     end = _range.end;
-    if (end.column < lineLength) {
-      break;
-    }
-    _row++;
-  }
-  return [start, end];
-};
-
-DocBlockrAtom.prototype.get_parser = function (editor) {
-  const scope = editor.getGrammar().scopeName;
-  const regex = /\bsource\.([a-z+-]+)(?:\.([a-z+-]+))?/;
-  const matches = regex.exec(scope);
-  const sourceLang = (matches === null) ? null : matches[1];
-  const subSourceLang = (matches === null || matches[2] === null) ? null : matches[2];
-
-  const settings = global.atom.config.get('docblockr');
-
-  if ((sourceLang === null) && (scope === 'text.html.php')) {
-    return new Parsers.PhpParser(settings);
-  }
-
-  if (sourceLang === 'coffee') {
-    return new Parsers.CoffeeParser(settings);
-  } else if ((sourceLang === 'actionscript') || (sourceLang === 'haxe')) {
-    return new Parsers.ActionscriptParser(settings);
-  } else if ((sourceLang === 'c++') || (sourceLang === 'cpp') || (sourceLang === 'c') || (sourceLang === 'cuda-c++')) {
-    return new Parsers.CppParser(settings);
-  } else if ((sourceLang === 'objc') || (sourceLang === 'objc++')) {
-    return new Parsers.ObjCParser(settings);
-  } else if ((sourceLang === 'java') || (sourceLang === 'groovy')) {
-    return new Parsers.JavaParser(settings);
-  } else if (sourceLang === 'rust') {
-    return new Parsers.RustParser(settings);
-  } else if (sourceLang === 'ts') {
-    return new Parsers.TypescriptParser(settings);
-  } else if (sourceLang === 'processing') {
-    return new Parsers.ProcessingParser(settings);
-  } else if (sourceLang === 'css' && subSourceLang === 'scss') {
-    return new Parsers.SassParser(settings);
-  }
-  return new Parsers.JsParser(settings);
-};
-
-DocBlockrAtom.prototype.generate_snippet = function (out, inline) {
-  // # substitute any variables in the tags
-
-  if (out) { out = this.substitute_variables(out); }
-
-  // align the tags
-  if (out && (this.shallowAlignTags || this.deepAlignTags) && (!inline)) { out = this.align_tags(out); }
-
-  // fix all the tab stops so they're consecutive
-  if (out) { out = this.fix_tabStops(out); }
-
-  if (inline) {
-    if (out) { return (' ' + out[0] + ' */'); } else { return (' $0 */'); }
-  } else { return (this.create_snippet(out) + (this.editor_settings.newline_after_block ? '\n' : '')); }
-};
-
-DocBlockrAtom.prototype.substitute_variables = function (out) {
-  function getConst (match, group, str) {
-    const varName = group;
-    if (varName === 'datetime') {
-      const datetime = new Date();
-      return formatTime(datetime);
-    } else if (varName === 'date') {
-      const datetime = new Date();
-      return datetime.toISOString().replace(/T.*/, '');
-    } else { return match; }
-  }
-  function formatTime (datetime) {
-    function lengthFix (x) {
-      if (x < 10) { x = '0' + x; }
-      return x;
-    }
-    const hour = lengthFix(datetime.getHours());
-    const min = lengthFix(datetime.getMinutes());
-    const sec = lengthFix(datetime.getSeconds());
-    const tz = datetime.getTimezoneOffset() / -60;
-    let tzString;
-    if (tz >= 0) { tzString = '+'; } else { tzString = '-'; }
-    tzString += lengthFix(Math.floor(Math.abs(tz)).toString()) + ((tz % 1) * 60);
-    datetime = datetime.toISOString().replace(/T.*/, '');
-    return (datetime += 'T' + hour + ':' + min + ':' + sec + tzString);
-  }
-  function subLine (line) {
-    const regex = /\{\{([^}]+)\}\}/g;
-    return line.replace(regex, getConst);
-  }
-  return out.map(subLine);
-};
-
-DocBlockrAtom.prototype.align_tags = function (out) {
-  const outputWidth = function (str) {
-    // get the length of a string, after it is output as a snippet,
-    // "${1:foo}" --> 3
-    return str.replace(/[$][{]\d+:([^}]+)[}]/, '$1').replace('\\$', '$').length;
-  };
-    // count how many columns we have
-  let maxCols = 0;
-  // this is a 2d list of the widths per column per line
-  const widths = [];
-  let returnTag;
-  // Grab the return tag if required.
-  if (this.editor_settings.per_section_indent) { returnTag = this.editor_settings.returnTag || '@return'; } else { returnTag = false; }
-
-  for (let i = 0; i < out.length; i++) {
-    if (out[i].startsWith('@')) {
-      // Ignore the return tag if we're doing per-section indenting.
-      if (returnTag && out[i].startsWith(returnTag)) { continue; }
-      // ignore all the words after `@author`
-      const columns = (!out[i].startsWith('@author')) ? out[i].split(' ') : ['@author'];
-      widths.push(columns.map(outputWidth));
-      maxCols = Math.max(maxCols, widths[widths.length - 1].length);
-    }
-  }
-  // initialise a list to 0
-  const maxWidths = this.fill_array(maxCols);
-
-  if (this.shallowAlignTags) { maxCols = 1; }
-
-  for (let i = 0; i < maxCols; i++) {
-    for (let j = 0; j < widths.length; j++) {
-      if (i < widths[j].length) { maxWidths[i] = Math.max(maxWidths[i], widths[j][i]); }
-    }
-  }
-  // Convert to a dict so we can use .get()
-  // maxWidths = dict(enumerate(maxWidths))
-
-  // Minimum spaces between line columns
-  const minColSpaces = this.editor_settings.min_spaces_between_columns || 1;
-  for (let i = 0; i < out.length; i++) {
-    // format the spacing of columns, but ignore the author tag. (See #197)
-    if ((out[i].startsWith('@')) && (!out[i].startsWith('@author'))) {
-      const newOut = [];
-      const splitArray = out[i].split(' ');
-      for (let j = 0; j < splitArray.length; j++) {
-        newOut.push(splitArray[j]);
-        newOut.push(this.repeat(' ', minColSpaces) + (
-          this.repeat(' ', ((maxWidths[j] || 0) - outputWidth(splitArray[j])))
-        ));
+    while (_row >= 0) {
+      lineLength = editor.lineTextForBufferRow(_row).length;
+      _range = editor.bufferRangeForScopeAtPosition(scopeName, [_row, lineLength]);
+      if (_range == null) { break; }
+      start = _range.start;
+      if (start.column > 0) {
+        break;
       }
-      out[i] = newOut.join('').trim();
+      _row--;
     }
+    _row = point.row;
+    const lastRow = editor.getLastBufferRow();
+    while (_row <= lastRow) {
+      lineLength = editor.lineTextForBufferRow(_row).length;
+      _range = editor.bufferRangeForScopeAtPosition(scopeName, [_row, 0]);
+      if (_range == null) { break; }
+      end = _range.end;
+      if (end.column < lineLength) {
+        break;
+      }
+      _row++;
+    }
+    return [start, end];
   }
-  return out;
-};
 
-DocBlockrAtom.prototype.fix_tabStops = function (out) {
-  const tabIndex = this.counter();
-  const swapTabs = function (match, group1, group2, str) {
-    return (group1 + tabIndex() + group2);
-  };
-  for (let i = 0; i < out.length; i++) { out[i] = out[i].replace(/(\$\{)\d+(:[^}]+\})/g, swapTabs); }
-  return out;
-};
+  get_parser (editor) {
+    const scope = editor.getGrammar().scopeName;
+    const regex = /\bsource\.([a-z+-]+)(?:\.([a-z+-]+))?/;
+    const matches = regex.exec(scope);
+    const sourceLang = (matches === null) ? null : matches[1];
+    const subSourceLang = (matches === null || matches[2] === null) ? null : matches[2];
 
-DocBlockrAtom.prototype.create_snippet = function (out) {
-  let snippet = '';
-  const regex = /^\s*@([a-zA-Z]+)/;
-  if (out) {
-    if (this.editor_settings.spacerBetweenSections === 'true') {
-      let lastTag = null;
-      for (let i = 0; i < out.length; i++) {
-        const match = regex.exec(out[i]);
-        if (match && (lastTag !== match[1])) {
-          lastTag = match[1];
-          out.splice(i, 0, '');
-        }
-      }
-    } else if (this.editor_settings.spacerBetweenSections !== 'false') {
-      let lastLineIsTag = false;
-      for (let i = 0; i < out.length; i++) {
-        const match = regex.exec(out[i]);
-        if (match) {
-          if (!lastLineIsTag) { out.splice(i, 0, ''); }
-          lastLineIsTag = true;
-        }
-      }
+    const settings = global.atom.config.get('docblockr');
+
+    if ((sourceLang === null) && (scope === 'text.html.php')) {
+      return new Parsers.PhpParser(settings);
     }
+
+    if (sourceLang === 'coffee') {
+      return new Parsers.CoffeeParser(settings);
+    } else if ((sourceLang === 'actionscript') || (sourceLang === 'haxe')) {
+      return new Parsers.ActionscriptParser(settings);
+    } else if ((sourceLang === 'c++') || (sourceLang === 'cpp') || (sourceLang === 'c') || (sourceLang === 'cuda-c++')) {
+      return new Parsers.CppParser(settings);
+    } else if ((sourceLang === 'objc') || (sourceLang === 'objc++')) {
+      return new Parsers.ObjCParser(settings);
+    } else if ((sourceLang === 'java') || (sourceLang === 'groovy')) {
+      return new Parsers.JavaParser(settings);
+    } else if (sourceLang === 'rust') {
+      return new Parsers.RustParser(settings);
+    } else if (sourceLang === 'ts') {
+      return new Parsers.TypescriptParser(settings);
+    } else if (sourceLang === 'processing') {
+      return new Parsers.ProcessingParser(settings);
+    } else if (sourceLang === 'css' && subSourceLang === 'scss') {
+      return new Parsers.SassParser(settings);
+    }
+    return new Parsers.JsParser(settings);
+  }
+
+  generate_snippet (out, inline) {
+    // # substitute any variables in the tags
+
+    if (out) { out = this.substitute_variables(out); }
+
+    // align the tags
+    if (out && (this.shallowAlignTags || this.deepAlignTags) && (!inline)) { out = this.align_tags(out); }
+
+    // fix all the tab stops so they're consecutive
+    if (out) { out = this.fix_tabStops(out); }
+
+    if (inline) {
+      if (out) { return (' ' + out[0] + ' */'); } else { return (' $0 */'); }
+    } else { return (this.create_snippet(out) + (this.editor_settings.newline_after_block ? '\n' : '')); }
+  }
+
+  substitute_variables (out) {
+    function getConst (match, group, str) {
+      const varName = group;
+      if (varName === 'datetime') {
+        const datetime = new Date();
+        return formatTime(datetime);
+      } else if (varName === 'date') {
+        const datetime = new Date();
+        return datetime.toISOString().replace(/T.*/, '');
+      } else { return match; }
+    }
+    function formatTime (datetime) {
+      function lengthFix (x) {
+        if (x < 10) { x = '0' + x; }
+        return x;
+      }
+      const hour = lengthFix(datetime.getHours());
+      const min = lengthFix(datetime.getMinutes());
+      const sec = lengthFix(datetime.getSeconds());
+      const tz = datetime.getTimezoneOffset() / -60;
+      let tzString;
+      if (tz >= 0) { tzString = '+'; } else { tzString = '-'; }
+      tzString += lengthFix(Math.floor(Math.abs(tz)).toString()) + ((tz % 1) * 60);
+      datetime = datetime.toISOString().replace(/T.*/, '');
+      return (datetime += 'T' + hour + ':' + min + ':' + sec + tzString);
+    }
+    function subLine (line) {
+      const regex = /\{\{([^}]+)\}\}/g;
+      return line.replace(regex, getConst);
+    }
+    return out.map(subLine);
+  }
+
+  align_tags (out) {
+    const outputWidth = function (str) {
+      // get the length of a string, after it is output as a snippet,
+      // "${1:foo}" --> 3
+      return str.replace(/[$][{]\d+:([^}]+)[}]/, '$1').replace('\\$', '$').length;
+    };
+      // count how many columns we have
+    let maxCols = 0;
+    // this is a 2d list of the widths per column per line
+    const widths = [];
+    let returnTag;
+    // Grab the return tag if required.
+    if (this.editor_settings.per_section_indent) { returnTag = this.editor_settings.returnTag || '@return'; } else { returnTag = false; }
+
     for (let i = 0; i < out.length; i++) {
-      snippet += '\n' + this.prefix + (out[i] ? (this.indentSpaces + out[i]) : '');
+      if (out[i].startsWith('@')) {
+        // Ignore the return tag if we're doing per-section indenting.
+        if (returnTag && out[i].startsWith(returnTag)) { continue; }
+        // ignore all the words after `@author`
+        const columns = (!out[i].startsWith('@author')) ? out[i].split(' ') : ['@author'];
+        widths.push(columns.map(outputWidth));
+        maxCols = Math.max(maxCols, widths[widths.length - 1].length);
+      }
     }
-  } else { snippet += '\n' + this.prefix + this.indentSpaces + '${0:' + this.trailing_string + '}'; }
+    // initialise a list to 0
+    const maxWidths = this.fill_array(maxCols);
 
-  if (this.parser.settings.commentType === 'block') {
-    snippet += '\n' + this.parser.settings.commentCloser;
+    if (this.shallowAlignTags) { maxCols = 1; }
+
+    for (let i = 0; i < maxCols; i++) {
+      for (let j = 0; j < widths.length; j++) {
+        if (i < widths[j].length) { maxWidths[i] = Math.max(maxWidths[i], widths[j][i]); }
+      }
+    }
+    // Convert to a dict so we can use .get()
+    // maxWidths = dict(enumerate(maxWidths))
+
+    // Minimum spaces between line columns
+    const minColSpaces = this.editor_settings.min_spaces_between_columns || 1;
+    for (let i = 0; i < out.length; i++) {
+      // format the spacing of columns, but ignore the author tag. (See #197)
+      if ((out[i].startsWith('@')) && (!out[i].startsWith('@author'))) {
+        const newOut = [];
+        const splitArray = out[i].split(' ');
+        for (let j = 0; j < splitArray.length; j++) {
+          newOut.push(splitArray[j]);
+          newOut.push(this.repeat(' ', minColSpaces) + (
+            this.repeat(' ', ((maxWidths[j] || 0) - outputWidth(splitArray[j])))
+          ));
+        }
+        out[i] = newOut.join('').trim();
+      }
+    }
+    return out;
   }
 
-  return snippet;
-};
+  fix_tabStops (out) {
+    const tabIndex = this.counter();
+    const swapTabs = function (match, group1, group2, str) {
+      return (group1 + tabIndex() + group2);
+    };
+    for (let i = 0; i < out.length; i++) { out[i] = out[i].replace(/(\$\{)\d+(:[^}]+\})/g, swapTabs); }
+    return out;
+  }
+
+  create_snippet (out) {
+    let snippet = '';
+    const regex = /^\s*@([a-zA-Z]+)/;
+    if (out) {
+      if (this.editor_settings.spacerBetweenSections === 'true') {
+        let lastTag = null;
+        for (let i = 0; i < out.length; i++) {
+          const match = regex.exec(out[i]);
+          if (match && (lastTag !== match[1])) {
+            lastTag = match[1];
+            out.splice(i, 0, '');
+          }
+        }
+      } else if (this.editor_settings.spacerBetweenSections !== 'false') {
+        let lastLineIsTag = false;
+        for (let i = 0; i < out.length; i++) {
+          const match = regex.exec(out[i]);
+          if (match) {
+            if (!lastLineIsTag) { out.splice(i, 0, ''); }
+            lastLineIsTag = true;
+          }
+        }
+      }
+      for (let i = 0; i < out.length; i++) {
+        snippet += '\n' + this.prefix + (out[i] ? (this.indentSpaces + out[i]) : '');
+      }
+    } else { snippet += '\n' + this.prefix + this.indentSpaces + '${0:' + this.trailing_string + '}'; }
+
+    if (this.parser.settings.commentType === 'block') {
+      snippet += '\n' + this.parser.settings.commentCloser;
+    }
+
+    return snippet;
+  }
+}
 
 module.exports = DocBlockrAtom;

--- a/lib/docblockr-worker.js
+++ b/lib/docblockr-worker.js
@@ -25,7 +25,6 @@ class DocBlockrAtom {
     });
 
     global.atom.commands.add('atom-workspace', 'docblockr:parse-tab', event => {
-      this.event = event;
       const regex = {
         // Parse Command
         parse: /^\s*(\/\*([*!])|###\*|\/\/\*)\s*$/,
@@ -33,17 +32,18 @@ class DocBlockrAtom {
         indent: /^(\s*\*|\/\/\/)\s*$/
       };
 
-      if (this.validateRequest({ preceding: true, precedingRegex: regex.parse })) {
+      if (this.validateRequest(event, { preceding: true, precedingRegex: regex.parse })) {
         // Parse Command
-        this.parseCommand(false);
-      } else if (this.validateRequest({ preceding: true, precedingRegex: regex.indent })) {
+        this.parseCommand(event, false);
+      } else if (this.validateRequest(event, { preceding: true, precedingRegex: regex.indent })) {
         // Indent Command
-        this.indentCommand();
-      } else { this.event.abortKeyBinding(); }
+        this.indentCommand(event);
+      } else {
+        event.abortKeyBinding();
+      }
     });
 
     global.atom.commands.add('atom-workspace', 'docblockr:parse-enter', event => {
-      this.event = event;
       const regex = {
         // Parse Command
         parse: /^\s*(\/\*([*!])|###\*|\/\/\*)\s*$/,
@@ -61,81 +61,76 @@ class DocBlockrAtom {
         extend: /^\s*\*(?:.?|.*(?:[^*][^/]|[^*]\/|\*[^/]))\s*$/
       };
 
-      if (this.validateRequest({ preceding: true, precedingRegex: regex.parse })) {
+      if (this.validateRequest(event, { preceding: true, precedingRegex: regex.parse })) {
         // Parse Command
-        this.parseCommand(false);
-      } else if (this.validateRequest({ preceding: true, precedingRegex: regex.trimAuto[0], following: true, followingRegex: regex.trimAuto[1], scope: 'comment.block' })) {
+        this.parseCommand(event, false);
+      } else if (this.validateRequest(event, { preceding: true, precedingRegex: regex.trimAuto[0], following: true, followingRegex: regex.trimAuto[1], scope: 'comment.block' })) {
         // Trim auto whitespace
-        this.trimAutoWhitespaceCommand();
-      } else if (this.validateRequest({ preceding: true, precedingRegex: regex.deindent })) {
+        this.trimAutoWhitespaceCommand(event);
+      } else if (this.validateRequest(event, { preceding: true, precedingRegex: regex.deindent })) {
         // Deindent command
-        this.deindentCommand();
-      } else if (this.validateRequest({ preceding: true, precedingRegex: regex.snippetOne[0], following: true, followingRegex: regex.snippetOne[1] })) {
+        this.deindentCommand(event);
+      } else if (this.validateRequest(event, { preceding: true, precedingRegex: regex.snippetOne[0], following: true, followingRegex: regex.snippetOne[1] })) {
         // Snippet-1 command
-        const editor = this.getRelevantEditor();
-        this.write(editor, '\n$0\n ');
-      } else if (this.validateRequest({ preceding: true, precedingRegex: regex.closeBlock })) {
+        this.write(event, '\n$0\n ');
+      } else if (this.validateRequest(event, { preceding: true, precedingRegex: regex.closeBlock })) {
         // Close block comment command
-        this.parseBlockCommand();
-      } else if ((this.editorSettings.extend_double_slash === true) && (this.validateRequest({ preceding: true, precedingRegex: regex.extendLine, scope: 'comment.line' }))) {
+        this.parseBlockCommand(event);
+      } else if ((this.editorSettings.extend_double_slash === true) && (this.validateRequest(event, { preceding: true, precedingRegex: regex.extendLine, scope: 'comment.line' }))) {
         // Extend line comments (// and #)
         const _regex = /^(\s*[^\sa-z0-9]*\s*).*$/;
-        const editor = this.getRelevantEditor();
+        const editor = event.target.closest('atom-text-editor').getModel();
         const cursorPosition = editor.getCursorBufferPosition();
         let lineText = editor.lineTextForBufferRow(cursorPosition.row);
         lineText = lineText.replace(_regex, '$1');
         editor.insertText('\n' + lineText);
-      } else if (this.validateRequest({ preceding: true, precedingRegex: regex.extend, scope: 'comment.block' })) {
+      } else if (this.validateRequest(event, { preceding: true, precedingRegex: regex.extend, scope: 'comment.block' })) {
         // Extend docblock by adding an asterix at start
         const _regex = /^(\s*\*\s*).*$/;
-        const editor = this.getRelevantEditor();
+        const editor = event.target.closest('atom-text-editor').getModel();
         const cursorPosition = editor.getCursorBufferPosition();
         let lineText = editor.lineTextForBufferRow(cursorPosition.row);
         lineText = lineText.replace(_regex, '$1');
         editor.insertText('\n' + lineText);
-      } else { this.event.abortKeyBinding(); }
+      } else {
+        event.abortKeyBinding();
+      }
     });
 
     global.atom.commands.add('atom-workspace', 'docblockr:parse-inline', event => {
-      this.event = event;
       // console.log('Parse-Inline command');
       const _regex = /^\s*\/\*{2}$/;
 
-      if (this.validateRequest({ preceding: true, precedingRegex: _regex })) { this.parseCommand(true); } else {
-        const editor = this.getRelevantEditor();
+      if (this.validateRequest(event, { preceding: true, precedingRegex: _regex })) { this.parseCommand(event, true); } else {
+        const editor = event.target.closest('atom-text-editor').getModel();
         editor.insertNewline();
         // event.abortKeyBinding();
       }
     });
 
     global.atom.commands.add('atom-workspace', 'docblockr:join', event => {
-      this.event = event;
       // console.log('Join command');
-      if (this.validateRequest({ scope: 'comment.block' })) { this.joinCommand(); }
+      if (this.validateRequest(event, { scope: 'comment.block' })) { this.joinCommand(event); }
     });
 
     global.atom.commands.add('atom-workspace', 'docblockr:reparse', event => {
-      this.event = event;
       // console.log('Reparse command');
-      if (this.validateRequest({ scope: 'comment.block' })) { this.reparseCommand(); }
+      if (this.validateRequest(event, { scope: 'comment.block' })) { this.reparseCommand(event); }
     });
 
     global.atom.commands.add('atom-workspace', 'docblockr:wrap-lines', event => {
-      this.event = event;
       // console.log('Wraplines command');
-      if (this.validateRequest({ scope: 'comment.block' })) { this.wrapLinesCommand(); }
+      if (this.validateRequest(event, { scope: 'comment.block' })) { this.wrapLinesCommand(event); }
     });
 
     global.atom.commands.add('atom-workspace', 'docblockr:decorate', event => {
-      this.event = event;
       // console.log('Decorate command');
-      if (this.validateRequest({ scope: 'comment.line.double-slash' })) { this.decorateCommand(); }
+      if (this.validateRequest(event, { scope: 'comment.line' })) { this.decorateCommand(event); }
     });
 
     global.atom.commands.add('atom-workspace', 'docblockr:decorate-multiline', event => {
-      this.event = event;
       // console.log('Decorate Multiline command');
-      if (this.validateRequest({ scope: 'comment.block' })) { this.decorateMultilineCommand(); }
+      if (this.validateRequest(event, { scope: 'comment.block' })) { this.decorateMultilineCommand(event); }
     });
   }
 
@@ -152,7 +147,7 @@ class DocBlockrAtom {
      * @param  {Regex}    followingRegex  Regex to check following text against
      * @param  {String}   scope            Check if cursor matches scope
      */
-  validateRequest (options) {
+  validateRequest (event, options) {
     /**
        *  Multiple cursor behaviour:
        *   1. Add mulitple snippets dependent on cursor pos, this makes traversing
@@ -169,7 +164,7 @@ class DocBlockrAtom {
     const followingRegex = (typeof options.followingRegex !== 'undefined') ? options.followingRegex : '';
     const scope = (typeof options.scope !== 'undefined') ? options.scope : false;
 
-    const editor = this.getRelevantEditor(this.event);
+    const editor = event.target.closest('atom-text-editor').getModel();
     this.cursors = [];
     let i, len, followingText, precedingText;
 
@@ -229,14 +224,14 @@ class DocBlockrAtom {
     } else { return false; }
   }
 
-  parseCommand (inline) {
-    const editor = this.getRelevantEditor();
+  parseCommand (event, inline) {
+    const editor = event.target.closest('atom-text-editor').getModel();
     if (typeof editor === 'undefined' || editor === null) {
       return;
     }
     this.initialize(editor, inline);
     if (this.parser.isExistingComment(this.line)) {
-      this.write(editor, '\n *' + this.indentSpaces);
+      this.write(event, '\n *' + this.indentSpaces);
       return;
     }
 
@@ -249,14 +244,14 @@ class DocBlockrAtom {
     // atom doesnt currently support, snippet end by default
     // so add $0
     if ((snippet.search(/\${0:/) < 0) && (snippet.search(/\$0/) < 0)) { snippet += '$0'; }
-    this.write(editor, snippet);
+    this.write(event, snippet);
   }
 
   /**
-     * Perform actions for a single-asterix block comment
-     */
-  parseBlockCommand () {
-    const editor = this.getRelevantEditor();
+   * Perform actions for a single-asterix block comment
+   */
+  parseBlockCommand (event) {
+    const editor = event.target.closest('atom-text-editor').getModel();
     if (typeof editor === 'undefined' || editor === null) {
       return;
     }
@@ -284,14 +279,14 @@ class DocBlockrAtom {
       string += '\n */';
     }
 
-    this.write(editor, string);
+    this.write(event, string);
   }
 
-  trimAutoWhitespaceCommand () {
+  trimAutoWhitespaceCommand (event) {
     /**
-       * Trim the automatic whitespace added when creating a new line in a docblock.
-       */
-    const editor = this.getRelevantEditor();
+     * Trim the automatic whitespace added when creating a new line in a docblock.
+     */
+    const editor = event.target.closest('atom-text-editor').getModel();
     if (typeof editor === 'undefined' || editor === null) {
       return;
     }
@@ -306,8 +301,8 @@ class DocBlockrAtom {
     editor.setTextInBufferRange(range, lineText);
   }
 
-  indentCommand () {
-    const editor = this.getRelevantEditor();
+  indentCommand (event) {
+    const editor = event.target.closest('atom-text-editor').getModel();
     const currentPos = editor.getCursorBufferPosition();
     const prevLine = editor.lineTextForBufferRow(currentPos.row - 1);
     const spaces = this.getIndentSpaces(editor, prevLine);
@@ -316,20 +311,16 @@ class DocBlockrAtom {
       const matches = /^(\s*(?:\*|\/\/\/))/.exec(prevLine);
       const toStar = matches[1].length;
       const toInsert = spaces - currentPos.column + toStar;
-      if (toInsert <= 0) {
-        if (this.event) {
-          this.event.abortKeyBinding();
-        }
-        return;
+      if (toInsert > 0) {
+        editor.insertText(this.repeat(' ', toInsert));
       }
-      editor.insertText(this.repeat(' ', toInsert));
-    } else if (this.event) {
-      this.event.abortKeyBinding();
+      return;
     }
+    event.abortKeyBinding();
   }
 
-  joinCommand () {
-    const editor = this.getRelevantEditor();
+  joinCommand (event) {
+    const editor = event.target.closest('atom-text-editor').getModel();
     const selections = editor.getSelections();
     let i, j, rowBegin;
     const textWithEnding = row => editor.buffer.lineForRow(row) + editor.buffer.lineEndingForRow(row);
@@ -358,8 +349,8 @@ class DocBlockrAtom {
     }
   }
 
-  decorateCommand () {
-    const editor = this.getRelevantEditor();
+  decorateCommand (event) {
+    const editor = event.target.closest('atom-text-editor').getModel();
     const pos = editor.getCursorBufferPosition();
     const whitespaceRe = /^(\s*)\/\//;
     const scopeRange = this.scopeRange(editor, pos, 'comment.line.double-slash');
@@ -394,8 +385,8 @@ class DocBlockrAtom {
     editor.buffer.insert(scopeRange[0], this.repeat('/', lineLength + 3) + '\n');
   }
 
-  decorateMultilineCommand () {
-    const editor = this.getRelevantEditor();
+  decorateMultilineCommand (event) {
+    const editor = event.target.closest('atom-text-editor').getModel();
     const pos = editor.getCursorBufferPosition();
     const whitespaceRe = /^(\s*)\/\*/;
     const tabSize = global.atom.config.get('editor.tabLength');
@@ -450,7 +441,7 @@ class DocBlockrAtom {
     }
   }
 
-  deindentCommand () {
+  deindentCommand (event) {
     /*
        * When pressing enter at the end of a docblock, this takes the cursor back one space.
       /**
@@ -458,17 +449,17 @@ class DocBlockrAtom {
        *//* |   <-- from here
       |      <-- to here
        */
-    const editor = this.getRelevantEditor();
+    const editor = event.target.closest('atom-text-editor').getModel();
     const cursor = editor.getCursorBufferPosition();
     let text = editor.lineTextForBufferRow(cursor.row);
     text = text.replace(/^(\s*)\s\*\/.*/, '\n$1');
     editor.insertText(text, { autoIndentNewline: false });
   }
 
-  reparseCommand () {
+  reparseCommand (event) {
     // Reparse a docblock to make the fields 'active' again, so that pressing tab will jump to the next one
     const tabIndex = this.counter();
-    const editor = this.getRelevantEditor();
+    const editor = event.target.closest('atom-text-editor').getModel();
     const pos = editor.getCursorBufferPosition();
     // const Snippets = global.atom.packages.activePackages.snippets.mainModule;
     // disable all snippet expansions
@@ -486,16 +477,16 @@ class DocBlockrAtom {
     editor.buffer.delete(([scopeRange[0], scopeRange[1]]));
     editor.setCursorBufferPosition(scopeRange[0]);
     if ((text.search(/\${0:/) < 0) && (text.search(/\$0/) < 0)) { text += '$0'; }
-    this.write(editor, text);
+    this.write(event, text);
   }
 
-  wrapLinesCommand () {
+  wrapLinesCommand (event) {
     /**
-       * Reformat description text inside a comment block to wrap at the correct length.
-       *  Wrap column is set by the first ruler (set in Default.sublime-settings), or 80 by default.
-       * Shortcut Key: alt+q
-       */
-    const editor = this.getRelevantEditor();
+     * Reformat description text inside a comment block to wrap at the correct length.
+     * Wrap column is set by the first ruler (set in Default.sublime-settings), or 80 by default.
+     * Shortcut Key: alt+q
+     */
+    const editor = event.target.closest('atom-text-editor').getModel();
     const pos = editor.getCursorBufferPosition();
     // const tabSize = global.atom.config.get('editor.tabLength');
     const wrapLen = global.atom.config.get('editor.preferredLineLength');
@@ -697,7 +688,8 @@ class DocBlockrAtom {
     return Array(Math.max(0, number) + 1).join(string);
   }
 
-  write (editor, str) {
+  write (event, str) {
+    const editor = event.target.closest('atom-text-editor').getModel();
     // will insert data at last cursor position
     if (this.snippetsService) { this.snippetsService.insertSnippet(str, editor); } else {
       global.atom.notifications.addFatalError('Docblockr: Snippets package disabled.', {
@@ -705,7 +697,7 @@ class DocBlockrAtom {
         dismissable: true,
         icon: 'flame'
       });
-      if (this.event) { this.event.abortKeyBinding(); }
+      event.abortKeyBinding();
     }
   }
 
@@ -722,17 +714,6 @@ class DocBlockrAtom {
       i++;
     }
     return a;
-  }
-
-  getRelevantEditor () {
-    let atomTextEditor;
-    if (this.event && this.event.target) {
-      atomTextEditor = this.event.target.closest('atom-text-editor');
-      if (atomTextEditor) { return atomTextEditor.getModel(); }
-    }
-    const editor = global.atom.workspace.getActiveTextEditor();
-    if (editor !== undefined) { return editor; }
-    return null;
   }
 
   readLine (editor, point) {

--- a/lib/docblockr-worker.js
+++ b/lib/docblockr-worker.js
@@ -19,10 +19,10 @@ class DocBlockrAtom {
   constructor () {
     const self = this;
     const settings = global.atom.config.get('docblockr');
-    this.editor_settings = settings;
+    this.editorSettings = settings;
 
     global.atom.config.observe('docblockr', function () {
-      self.update_config();
+      self.updateConfig();
     });
 
     global.atom.commands.add('atom-workspace', 'docblockr:parse-tab', function (event) {
@@ -34,12 +34,12 @@ class DocBlockrAtom {
         indent: /^(\s*\*|\/\/\/)\s*$/
       };
 
-      if (self.validate_request({ preceding: true, precedingRegex: regex.parse })) {
+      if (self.validateRequest({ preceding: true, precedingRegex: regex.parse })) {
         // Parse Command
-        self.parse_command(false);
-      } else if (self.validate_request({ preceding: true, precedingRegex: regex.indent })) {
+        self.parseCommand(false);
+      } else if (self.validateRequest({ preceding: true, precedingRegex: regex.indent })) {
         // Indent Command
-        self.indent_command();
+        self.indentCommand();
       } else { self.event.abortKeyBinding(); }
     });
 
@@ -49,47 +49,47 @@ class DocBlockrAtom {
         // Parse Command
         parse: /^\s*(\/\*([*!])|###\*|\/\/\*)\s*$/,
         // Trim auto whitespace
-        trim_auto: [/^\s*\*\s*$/, /^\s*$/],
+        trimAuto: [/^\s*\*\s*$/, /^\s*$/],
         // Deindent Command
         deindent: /^\s+\*\//,
         // Snippet-1
-        snippet_1: [/^\s*\/\*$/, /^\*\/\s*$/],
+        snippetOne: [/^\s*\/\*$/, /^\*\/\s*$/],
         // Close block comment
-        close_block: /^\s*\/\*\s*$/,
+        closeBlock: /^\s*\/\*\s*$/,
         // extend line
-        extend_line: /^\s*(\/\/[/!]?|#)/,
+        extendLine: /^\s*(\/\/[/!]?|#)/,
         // Extend docblock by adding an asterix at start
         extend: /^\s*\*(?:.?|.*(?:[^*][^/]|[^*]\/|\*[^/]))\s*$/
       };
 
-      if (self.validate_request({ preceding: true, precedingRegex: regex.parse })) {
+      if (self.validateRequest({ preceding: true, precedingRegex: regex.parse })) {
         // Parse Command
-        self.parse_command(false);
-      } else if (self.validate_request({ preceding: true, precedingRegex: regex.trim_auto[0], following: true, followingRegex: regex.trim_auto[1], scope: 'comment.block' })) {
+        self.parseCommand(false);
+      } else if (self.validateRequest({ preceding: true, precedingRegex: regex.trimAuto[0], following: true, followingRegex: regex.trimAuto[1], scope: 'comment.block' })) {
         // Trim auto whitespace
-        self.trim_auto_whitespace_command();
-      } else if (self.validate_request({ preceding: true, precedingRegex: regex.deindent })) {
+        self.trimAutoWhitespaceCommand();
+      } else if (self.validateRequest({ preceding: true, precedingRegex: regex.deindent })) {
         // Deindent command
-        self.deindent_command();
-      } else if (self.validate_request({ preceding: true, precedingRegex: regex.snippet_1[0], following: true, followingRegex: regex.snippet_1[1] })) {
+        self.deindentCommand();
+      } else if (self.validateRequest({ preceding: true, precedingRegex: regex.snippetOne[0], following: true, followingRegex: regex.snippetOne[1] })) {
         // Snippet-1 command
-        const editor = self.get_relevant_editor();
+        const editor = self.getRelevantEditor();
         self.write(editor, '\n$0\n ');
-      } else if (self.validate_request({ preceding: true, precedingRegex: regex.close_block })) {
+      } else if (self.validateRequest({ preceding: true, precedingRegex: regex.closeBlock })) {
         // Close block comment command
-        self.parse_block_command();
-      } else if ((self.editor_settings.extend_double_slash === true) && (self.validate_request({ preceding: true, precedingRegex: regex.extend_line, scope: 'comment.line' }))) {
+        self.parseBlockCommand();
+      } else if ((self.editorSettings.extend_double_slash === true) && (self.validateRequest({ preceding: true, precedingRegex: regex.extendLine, scope: 'comment.line' }))) {
         // Extend line comments (// and #)
         const _regex = /^(\s*[^\sa-z0-9]*\s*).*$/;
-        const editor = self.get_relevant_editor();
+        const editor = self.getRelevantEditor();
         const cursorPosition = editor.getCursorBufferPosition();
         let lineText = editor.lineTextForBufferRow(cursorPosition.row);
         lineText = lineText.replace(_regex, '$1');
         editor.insertText('\n' + lineText);
-      } else if (self.validate_request({ preceding: true, precedingRegex: regex.extend, scope: 'comment.block' })) {
+      } else if (self.validateRequest({ preceding: true, precedingRegex: regex.extend, scope: 'comment.block' })) {
         // Extend docblock by adding an asterix at start
         const _regex = /^(\s*\*\s*).*$/;
-        const editor = self.get_relevant_editor();
+        const editor = self.getRelevantEditor();
         const cursorPosition = editor.getCursorBufferPosition();
         let lineText = editor.lineTextForBufferRow(cursorPosition.row);
         lineText = lineText.replace(_regex, '$1');
@@ -102,8 +102,8 @@ class DocBlockrAtom {
       // console.log('Parse-Inline command');
       const _regex = /^\s*\/\*{2}$/;
 
-      if (self.validate_request({ preceding: true, precedingRegex: _regex })) { self.parse_command(true); } else {
-        const editor = self.get_relevant_editor();
+      if (self.validateRequest({ preceding: true, precedingRegex: _regex })) { self.parseCommand(true); } else {
+        const editor = self.getRelevantEditor();
         editor.insertNewline();
         // event.abortKeyBinding();
       }
@@ -112,37 +112,37 @@ class DocBlockrAtom {
     global.atom.commands.add('atom-workspace', 'docblockr:join', function (event) {
       self.event = event;
       // console.log('Join command');
-      if (self.validate_request({ scope: 'comment.block' })) { self.join_command(); }
+      if (self.validateRequest({ scope: 'comment.block' })) { self.joinCommand(); }
     });
 
     global.atom.commands.add('atom-workspace', 'docblockr:reparse', function (event) {
       self.event = event;
       // console.log('Reparse command');
-      if (self.validate_request({ scope: 'comment.block' })) { self.reparse_command(); }
+      if (self.validateRequest({ scope: 'comment.block' })) { self.reparseCommand(); }
     });
 
     global.atom.commands.add('atom-workspace', 'docblockr:wrap-lines', function (event) {
       self.event = event;
       // console.log('Wraplines command');
-      if (self.validate_request({ scope: 'comment.block' })) { self.wrap_lines_command(); }
+      if (self.validateRequest({ scope: 'comment.block' })) { self.wrapLinesCommand(); }
     });
 
     global.atom.commands.add('atom-workspace', 'docblockr:decorate', function (event) {
       self.event = event;
       // console.log('Decorate command');
-      if (self.validate_request({ scope: 'comment.line.double-slash' })) { self.decorate_command(); }
+      if (self.validateRequest({ scope: 'comment.line.double-slash' })) { self.decorateCommand(); }
     });
 
     global.atom.commands.add('atom-workspace', 'docblockr:decorate-multiline', function (event) {
       self.event = event;
       // console.log('Decorate Multiline command');
-      if (self.validate_request({ scope: 'comment.block' })) { self.decorate_multiline_command(); }
+      if (self.validateRequest({ scope: 'comment.block' })) { self.decorateMultilineCommand(); }
     });
   }
 
-  update_config () {
+  updateConfig () {
     const settings = global.atom.config.get('docblockr');
-    this.editor_settings = settings;
+    this.editorSettings = settings;
   }
 
   /**
@@ -153,7 +153,7 @@ class DocBlockrAtom {
      * @param  {Regex}    followingRegex  Regex to check following text against
      * @param  {String}   scope            Check if cursor matches scope
      */
-  validate_request (options) {
+  validateRequest (options) {
     /**
        *  Multiple cursor behaviour:
        *   1. Add mulitple snippets dependent on cursor pos, this makes traversing
@@ -170,7 +170,7 @@ class DocBlockrAtom {
     const followingRegex = (typeof options.followingRegex !== 'undefined') ? options.followingRegex : '';
     const scope = (typeof options.scope !== 'undefined') ? options.scope : false;
 
-    const editor = this.get_relevant_editor(this.event);
+    const editor = this.getRelevantEditor(this.event);
     this.cursors = [];
     let i, len, followingText, precedingText;
 
@@ -232,23 +232,23 @@ class DocBlockrAtom {
     } else { return false; }
   }
 
-  parse_command (inline) {
-    const editor = this.get_relevant_editor();
+  parseCommand (inline) {
+    const editor = this.getRelevantEditor();
     if (typeof editor === 'undefined' || editor === null) {
       return;
     }
     this.initialize(editor, inline);
-    if (this.parser.is_existing_comment(this.line)) {
+    if (this.parser.isExistingComment(this.line)) {
       this.write(editor, '\n *' + this.indentSpaces);
       return;
     }
 
     // erase characters in the view (will be added to the output later)
-    this.erase(editor, this.trailing_range);
+    this.erase(editor, this.trailingRange);
 
     // match against a function declaration.
     const out = this.parser.parse(this.line);
-    let snippet = this.generate_snippet(out, inline);
+    let snippet = this.generateSnippet(out, inline);
     // atom doesnt currently support, snippet end by default
     // so add $0
     if ((snippet.search(/\${0:/) < 0) && (snippet.search(/\$0/) < 0)) { snippet += '$0'; }
@@ -258,21 +258,21 @@ class DocBlockrAtom {
   /**
      * Perform actions for a single-asterix block comment
      */
-  parse_block_command () {
-    const editor = this.get_relevant_editor();
+  parseBlockCommand () {
+    const editor = this.getRelevantEditor();
     if (typeof editor === 'undefined' || editor === null) {
       return;
     }
     this.initialize(editor, false);
 
     // Remove trailing characters (will write them appropriately later)
-    this.erase(editor, this.trailing_range);
+    this.erase(editor, this.trailingRange);
 
     // Build the string to write
     let string = '\n';
 
     // Might include asterixes
-    if (this.editor_settings.c_style_block_comments) {
+    if (this.editorSettings.c_style_block_comments) {
       string += ' *' + this.indentSpaces;
     }
 
@@ -280,28 +280,28 @@ class DocBlockrAtom {
     // trailing characters
 
     string += '$0';
-    string += this.trailing_string;
+    string += this.trailingString;
 
     // Close if needed
-    if (!this.parser.is_existing_comment(this.line)) {
+    if (!this.parser.isExistingComment(this.line)) {
       string += '\n */';
     }
 
     this.write(editor, string);
   }
 
-  trim_auto_whitespace_command () {
+  trimAutoWhitespaceCommand () {
     /**
        * Trim the automatic whitespace added when creating a new line in a docblock.
        */
-    const editor = this.get_relevant_editor();
+    const editor = this.getRelevantEditor();
     if (typeof editor === 'undefined' || editor === null) {
       return;
     }
     const cursorPosition = editor.getCursorBufferPosition();
     let lineText = editor.lineTextForBufferRow(cursorPosition.row);
     const lineLength = editor.lineTextForBufferRow(cursorPosition.row).length;
-    const spaces = Math.max(0, this.editor_settings.indentation_spaces);
+    const spaces = Math.max(0, this.editorSettings.indentation_spaces);
 
     const regex = /^(\s*\*)\s*$/;
     lineText = lineText.replace(regex, ('$1\n$1' + this.repeat(' ', spaces)));
@@ -309,11 +309,11 @@ class DocBlockrAtom {
     editor.setTextInBufferRange(range, lineText);
   }
 
-  indent_command () {
-    const editor = this.get_relevant_editor();
+  indentCommand () {
+    const editor = this.getRelevantEditor();
     const currentPos = editor.getCursorBufferPosition();
     const prevLine = editor.lineTextForBufferRow(currentPos.row - 1);
-    const spaces = this.get_indentSpaces(editor, prevLine);
+    const spaces = this.getIndentSpaces(editor, prevLine);
 
     if (spaces !== null) {
       const matches = /^(\s*(?:\*|\/\/\/))/.exec(prevLine);
@@ -331,8 +331,8 @@ class DocBlockrAtom {
     }
   }
 
-  join_command () {
-    const editor = this.get_relevant_editor();
+  joinCommand () {
+    const editor = this.getRelevantEditor();
     const selections = editor.getSelections();
     let i, j, rowBegin;
     const textWithEnding = function (row) {
@@ -363,8 +363,8 @@ class DocBlockrAtom {
     }
   }
 
-  decorate_command () {
-    const editor = this.get_relevant_editor();
+  decorateCommand () {
+    const editor = this.getRelevantEditor();
     const pos = editor.getCursorBufferPosition();
     const whitespaceRe = /^(\s*)\/\//;
     const scopeRange = this.scopeRange(editor, pos, 'comment.line.double-slash');
@@ -399,8 +399,8 @@ class DocBlockrAtom {
     editor.buffer.insert(scopeRange[0], this.repeat('/', lineLength + 3) + '\n');
   }
 
-  decorate_multiline_command () {
-    const editor = this.get_relevant_editor();
+  decorateMultilineCommand () {
+    const editor = this.getRelevantEditor();
     const pos = editor.getCursorBufferPosition();
     const whitespaceRe = /^(\s*)\/\*/;
     const tabSize = global.atom.config.get('editor.tabLength');
@@ -463,7 +463,7 @@ class DocBlockrAtom {
     }
   }
 
-  deindent_command () {
+  deindentCommand () {
     /*
        * When pressing enter at the end of a docblock, this takes the cursor back one space.
       /**
@@ -471,20 +471,20 @@ class DocBlockrAtom {
        *//* |   <-- from here
       |      <-- to here
        */
-    const editor = this.get_relevant_editor();
+    const editor = this.getRelevantEditor();
     const cursor = editor.getCursorBufferPosition();
     let text = editor.lineTextForBufferRow(cursor.row);
     text = text.replace(/^(\s*)\s\*\/.*/, '\n$1');
     editor.insertText(text, { autoIndentNewline: false });
   }
 
-  reparse_command () {
+  reparseCommand () {
     // Reparse a docblock to make the fields 'active' again, so that pressing tab will jump to the next one
     const tabIndex = this.counter();
     const tabStop = function (m, g1) {
       return `\${${tabIndex()}:${g1}}`;
     };
-    const editor = this.get_relevant_editor();
+    const editor = this.getRelevantEditor();
     const pos = editor.getCursorBufferPosition();
     // const Snippets = global.atom.packages.activePackages.snippets.mainModule;
     // disable all snippet expansions
@@ -505,22 +505,22 @@ class DocBlockrAtom {
     this.write(editor, text);
   }
 
-  wrap_lines_command () {
+  wrapLinesCommand () {
     /**
        * Reformat description text inside a comment block to wrap at the correct length.
        *  Wrap column is set by the first ruler (set in Default.sublime-settings), or 80 by default.
        * Shortcut Key: alt+q
        */
-    const editor = this.get_relevant_editor();
+    const editor = this.getRelevantEditor();
     const pos = editor.getCursorBufferPosition();
     // const tabSize = global.atom.config.get('editor.tabLength');
     const wrapLen = global.atom.config.get('editor.preferredLineLength');
 
-    const numIndentSpaces = Math.max(0, (this.editor_settings.indentation_spaces ? this.editor_settings.indentation_spaces : 1));
+    const numIndentSpaces = Math.max(0, (this.editorSettings.indentation_spaces ? this.editorSettings.indentation_spaces : 1));
     const indentSpaces = this.repeat(' ', numIndentSpaces);
-    const indentSpacesSamePara = this.repeat(' ', (this.editor_settings.indentation_spaces_same_para ? this.editor_settings.indentation_spaces_same_para : numIndentSpaces));
-    const spacerBetweenSections = (this.editor_settings.spacerBetweenSections === 'true');
-    const spacerBetweenDescTags = (this.editor_settings.spacerBetweenSections !== 'false');
+    const indentSpacesSamePara = this.repeat(' ', (this.editorSettings.indentation_spaces_same_para ? this.editorSettings.indentation_spaces_same_para : numIndentSpaces));
+    const spacerBetweenSections = (this.editorSettings.spacer_between_sections === 'true');
+    const spacerBetweenDescTags = (this.editorSettings.spacer_between_sections !== 'false');
 
     const scopeRange = this.scopeRange(editor, pos, 'comment.block');
     // const text = editor.getTextInBufferRange([scopeRange[0], scopeRange[1]]);
@@ -651,8 +651,8 @@ class DocBlockrAtom {
     editor.setTextInBufferRange([startPoint, endPoint], text);
   }
 
-  get_indentSpaces (editor, line) {
-    const hasTypes = this.get_parser(editor).settings.typeInfo;
+  getIndentSpaces (editor, line) {
+    const hasTypes = this.getParser(editor).settings.typeInfo;
     const extraIndent = ((hasTypes === true) ? '\\s+\\S+' : '');
 
     const regex = [
@@ -675,19 +675,19 @@ class DocBlockrAtom {
     let cursorPosition = editor.getCursorBufferPosition(); // will handle only one instance
     // Get trailing string
     const lineLength = editor.lineTextForBufferRow(cursorPosition.row).length;
-    this.trailing_range = [cursorPosition, [cursorPosition.row, lineLength]];
-    this.trailing_string = editor.getTextInBufferRange(this.trailing_range);
+    this.trailingRange = [cursorPosition, [cursorPosition.row, lineLength]];
+    this.trailingString = editor.getTextInBufferRange(this.trailingRange);
     // drop trailing */
-    this.trailing_string = this.trailing_string.replace(/\s*\*\/\s*$/, '');
-    this.trailing_string = escape(this.trailing_string);
+    this.trailingString = this.trailingString.replace(/\s*\*\/\s*$/, '');
+    this.trailingString = escape(this.trailingString);
 
-    this.parser = this.get_parser(editor);
+    this.parser = this.getParser(editor);
     this.parser.inline = inline;
 
-    this.indentSpaces = this.repeat(' ', Math.max(0, (this.editor_settings.indentation_spaces || 1)));
-    this.prefix = this.get_parser(editor).settings.prefix || ' *';
+    this.indentSpaces = this.repeat(' ', Math.max(0, (this.editorSettings.indentation_spaces || 1)));
+    this.prefix = this.getParser(editor).settings.prefix || ' *';
 
-    const settingsAlignTags = this.editor_settings.align_tags || 'deep';
+    const settingsAlignTags = this.editorSettings.align_tags || 'deep';
     this.deepAlignTags = settingsAlignTags === 'deep';
     this.shallowAlignTags = ((settingsAlignTags === 'shallow') || (settingsAlignTags === true));
 
@@ -697,11 +697,11 @@ class DocBlockrAtom {
     // read the next line
     cursorPosition = cursorPosition.copy();
     cursorPosition.row += 1;
-    this.line = this.parser.get_definition(editor, cursorPosition, this.read_line);
+    this.line = this.parser.getDefinition(editor, cursorPosition, this.readLine);
   }
 
-  set_snippets_service (service) {
-    this.snippets_service = service;
+  setSnippetsService (service) {
+    this.snippetsService = service;
   }
 
   counter () {
@@ -717,7 +717,7 @@ class DocBlockrAtom {
 
   write (editor, str) {
     // will insert data at last cursor position
-    if (this.snippets_service) { this.snippets_service.insertSnippet(str, editor); } else {
+    if (this.snippetsService) { this.snippetsService.insertSnippet(str, editor); } else {
       global.atom.notifications.addFatalError('Docblockr: Snippets package disabled.', {
         detail: 'Please enable Snippets package for Docblockr to function properly.',
         dismissable: true,
@@ -732,7 +732,7 @@ class DocBlockrAtom {
     buffer.delete(range);
   }
 
-  fill_array (len) {
+  fillArray (len) {
     const a = [];
     let i = 0;
     while (i < len) {
@@ -742,7 +742,7 @@ class DocBlockrAtom {
     return a;
   }
 
-  get_relevant_editor () {
+  getRelevantEditor () {
     let atomTextEditor;
     if (this.event && this.event.target) {
       atomTextEditor = this.event.target.closest('atom-text-editor');
@@ -753,7 +753,7 @@ class DocBlockrAtom {
     return null;
   }
 
-  read_line (editor, point) {
+  readLine (editor, point) {
     // TODO: no longer works
     if (point >= editor.getText().length) { return; }
     return editor.lineTextForBufferRow(point.row);
@@ -796,7 +796,7 @@ class DocBlockrAtom {
     return [start, end];
   }
 
-  get_parser (editor) {
+  getParser (editor) {
     const scope = editor.getGrammar().scopeName;
     const regex = /\bsource\.([a-z+-]+)(?:\.([a-z+-]+))?/;
     const matches = regex.exec(scope);
@@ -831,23 +831,23 @@ class DocBlockrAtom {
     return new Parsers.JsParser(settings);
   }
 
-  generate_snippet (out, inline) {
+  generateSnippet (out, inline) {
     // # substitute any variables in the tags
 
-    if (out) { out = this.substitute_variables(out); }
+    if (out) { out = this.substituteVariables(out); }
 
     // align the tags
-    if (out && (this.shallowAlignTags || this.deepAlignTags) && (!inline)) { out = this.align_tags(out); }
+    if (out && (this.shallowAlignTags || this.deepAlignTags) && (!inline)) { out = this.alignTags(out); }
 
     // fix all the tab stops so they're consecutive
-    if (out) { out = this.fix_tabStops(out); }
+    if (out) { out = this.fixTabStops(out); }
 
     if (inline) {
       if (out) { return (' ' + out[0] + ' */'); } else { return (' $0 */'); }
-    } else { return (this.create_snippet(out) + (this.editor_settings.newline_after_block ? '\n' : '')); }
+    } else { return (this.createSnippet(out) + (this.editorSettings.newline_after_block ? '\n' : '')); }
   }
 
-  substitute_variables (out) {
+  substituteVariables (out) {
     function getConst (match, group, str) {
       const varName = group;
       if (varName === 'datetime') {
@@ -880,7 +880,7 @@ class DocBlockrAtom {
     return out.map(subLine);
   }
 
-  align_tags (out) {
+  alignTags (out) {
     const outputWidth = function (str) {
       // get the length of a string, after it is output as a snippet,
       // "${1:foo}" --> 3
@@ -892,7 +892,7 @@ class DocBlockrAtom {
     const widths = [];
     let returnTag;
     // Grab the return tag if required.
-    if (this.editor_settings.per_section_indent) { returnTag = this.editor_settings.returnTag || '@return'; } else { returnTag = false; }
+    if (this.editorSettings.per_section_indent) { returnTag = this.editorSettings.return_tag || '@return'; } else { returnTag = false; }
 
     for (let i = 0; i < out.length; i++) {
       if (out[i].startsWith('@')) {
@@ -905,7 +905,7 @@ class DocBlockrAtom {
       }
     }
     // initialise a list to 0
-    const maxWidths = this.fill_array(maxCols);
+    const maxWidths = this.fillArray(maxCols);
 
     if (this.shallowAlignTags) { maxCols = 1; }
 
@@ -918,7 +918,7 @@ class DocBlockrAtom {
     // maxWidths = dict(enumerate(maxWidths))
 
     // Minimum spaces between line columns
-    const minColSpaces = this.editor_settings.min_spaces_between_columns || 1;
+    const minColSpaces = this.editorSettings.min_spaces_between_columns || 1;
     for (let i = 0; i < out.length; i++) {
       // format the spacing of columns, but ignore the author tag. (See #197)
       if ((out[i].startsWith('@')) && (!out[i].startsWith('@author'))) {
@@ -936,7 +936,7 @@ class DocBlockrAtom {
     return out;
   }
 
-  fix_tabStops (out) {
+  fixTabStops (out) {
     const tabIndex = this.counter();
     const swapTabs = function (match, group1, group2, str) {
       return (group1 + tabIndex() + group2);
@@ -945,11 +945,11 @@ class DocBlockrAtom {
     return out;
   }
 
-  create_snippet (out) {
+  createSnippet (out) {
     let snippet = '';
     const regex = /^\s*@([a-zA-Z]+)/;
     if (out) {
-      if (this.editor_settings.spacerBetweenSections === 'true') {
+      if (this.editorSettings.spacer_between_sections === 'true') {
         let lastTag = null;
         for (let i = 0; i < out.length; i++) {
           const match = regex.exec(out[i]);
@@ -958,7 +958,7 @@ class DocBlockrAtom {
             out.splice(i, 0, '');
           }
         }
-      } else if (this.editor_settings.spacerBetweenSections !== 'false') {
+      } else if (this.editorSettings.spacer_between_sections !== 'false') {
         let lastLineIsTag = false;
         for (let i = 0; i < out.length; i++) {
           const match = regex.exec(out[i]);
@@ -971,7 +971,7 @@ class DocBlockrAtom {
       for (let i = 0; i < out.length; i++) {
         snippet += '\n' + this.prefix + (out[i] ? (this.indentSpaces + out[i]) : '');
       }
-    } else { snippet += '\n' + this.prefix + this.indentSpaces + '${0:' + this.trailing_string + '}'; }
+    } else { snippet += '\n' + this.prefix + this.indentSpaces + '${0:' + this.trailingString + '}'; }
 
     if (this.parser.settings.commentType === 'block') {
       snippet += '\n' + this.parser.settings.commentCloser;

--- a/lib/docblockr-worker.js
+++ b/lib/docblockr-worker.js
@@ -17,16 +17,15 @@ const util = require('util');
 // const Snippets = global.atom.packages.activePackages.snippets.mainModule;
 class DocBlockrAtom {
   constructor () {
-    const self = this;
     const settings = global.atom.config.get('docblockr');
     this.editorSettings = settings;
 
-    global.atom.config.observe('docblockr', function () {
-      self.updateConfig();
+    global.atom.config.observe('docblockr', () => {
+      this.updateConfig();
     });
 
-    global.atom.commands.add('atom-workspace', 'docblockr:parse-tab', function (event) {
-      self.event = event;
+    global.atom.commands.add('atom-workspace', 'docblockr:parse-tab', event => {
+      this.event = event;
       const regex = {
         // Parse Command
         parse: /^\s*(\/\*([*!])|###\*|\/\/\*)\s*$/,
@@ -34,17 +33,17 @@ class DocBlockrAtom {
         indent: /^(\s*\*|\/\/\/)\s*$/
       };
 
-      if (self.validateRequest({ preceding: true, precedingRegex: regex.parse })) {
+      if (this.validateRequest({ preceding: true, precedingRegex: regex.parse })) {
         // Parse Command
-        self.parseCommand(false);
-      } else if (self.validateRequest({ preceding: true, precedingRegex: regex.indent })) {
+        this.parseCommand(false);
+      } else if (this.validateRequest({ preceding: true, precedingRegex: regex.indent })) {
         // Indent Command
-        self.indentCommand();
-      } else { self.event.abortKeyBinding(); }
+        this.indentCommand();
+      } else { this.event.abortKeyBinding(); }
     });
 
-    global.atom.commands.add('atom-workspace', 'docblockr:parse-enter', function (event) {
-      self.event = event;
+    global.atom.commands.add('atom-workspace', 'docblockr:parse-enter', event => {
+      this.event = event;
       const regex = {
         // Parse Command
         parse: /^\s*(\/\*([*!])|###\*|\/\/\*)\s*$/,
@@ -62,81 +61,81 @@ class DocBlockrAtom {
         extend: /^\s*\*(?:.?|.*(?:[^*][^/]|[^*]\/|\*[^/]))\s*$/
       };
 
-      if (self.validateRequest({ preceding: true, precedingRegex: regex.parse })) {
+      if (this.validateRequest({ preceding: true, precedingRegex: regex.parse })) {
         // Parse Command
-        self.parseCommand(false);
-      } else if (self.validateRequest({ preceding: true, precedingRegex: regex.trimAuto[0], following: true, followingRegex: regex.trimAuto[1], scope: 'comment.block' })) {
+        this.parseCommand(false);
+      } else if (this.validateRequest({ preceding: true, precedingRegex: regex.trimAuto[0], following: true, followingRegex: regex.trimAuto[1], scope: 'comment.block' })) {
         // Trim auto whitespace
-        self.trimAutoWhitespaceCommand();
-      } else if (self.validateRequest({ preceding: true, precedingRegex: regex.deindent })) {
+        this.trimAutoWhitespaceCommand();
+      } else if (this.validateRequest({ preceding: true, precedingRegex: regex.deindent })) {
         // Deindent command
-        self.deindentCommand();
-      } else if (self.validateRequest({ preceding: true, precedingRegex: regex.snippetOne[0], following: true, followingRegex: regex.snippetOne[1] })) {
+        this.deindentCommand();
+      } else if (this.validateRequest({ preceding: true, precedingRegex: regex.snippetOne[0], following: true, followingRegex: regex.snippetOne[1] })) {
         // Snippet-1 command
-        const editor = self.getRelevantEditor();
-        self.write(editor, '\n$0\n ');
-      } else if (self.validateRequest({ preceding: true, precedingRegex: regex.closeBlock })) {
+        const editor = this.getRelevantEditor();
+        this.write(editor, '\n$0\n ');
+      } else if (this.validateRequest({ preceding: true, precedingRegex: regex.closeBlock })) {
         // Close block comment command
-        self.parseBlockCommand();
-      } else if ((self.editorSettings.extend_double_slash === true) && (self.validateRequest({ preceding: true, precedingRegex: regex.extendLine, scope: 'comment.line' }))) {
+        this.parseBlockCommand();
+      } else if ((this.editorSettings.extend_double_slash === true) && (this.validateRequest({ preceding: true, precedingRegex: regex.extendLine, scope: 'comment.line' }))) {
         // Extend line comments (// and #)
         const _regex = /^(\s*[^\sa-z0-9]*\s*).*$/;
-        const editor = self.getRelevantEditor();
+        const editor = this.getRelevantEditor();
         const cursorPosition = editor.getCursorBufferPosition();
         let lineText = editor.lineTextForBufferRow(cursorPosition.row);
         lineText = lineText.replace(_regex, '$1');
         editor.insertText('\n' + lineText);
-      } else if (self.validateRequest({ preceding: true, precedingRegex: regex.extend, scope: 'comment.block' })) {
+      } else if (this.validateRequest({ preceding: true, precedingRegex: regex.extend, scope: 'comment.block' })) {
         // Extend docblock by adding an asterix at start
         const _regex = /^(\s*\*\s*).*$/;
-        const editor = self.getRelevantEditor();
+        const editor = this.getRelevantEditor();
         const cursorPosition = editor.getCursorBufferPosition();
         let lineText = editor.lineTextForBufferRow(cursorPosition.row);
         lineText = lineText.replace(_regex, '$1');
         editor.insertText('\n' + lineText);
-      } else { self.event.abortKeyBinding(); }
+      } else { this.event.abortKeyBinding(); }
     });
 
-    global.atom.commands.add('atom-workspace', 'docblockr:parse-inline', function (event) {
-      self.event = event;
+    global.atom.commands.add('atom-workspace', 'docblockr:parse-inline', event => {
+      this.event = event;
       // console.log('Parse-Inline command');
       const _regex = /^\s*\/\*{2}$/;
 
-      if (self.validateRequest({ preceding: true, precedingRegex: _regex })) { self.parseCommand(true); } else {
-        const editor = self.getRelevantEditor();
+      if (this.validateRequest({ preceding: true, precedingRegex: _regex })) { this.parseCommand(true); } else {
+        const editor = this.getRelevantEditor();
         editor.insertNewline();
         // event.abortKeyBinding();
       }
     });
 
-    global.atom.commands.add('atom-workspace', 'docblockr:join', function (event) {
-      self.event = event;
+    global.atom.commands.add('atom-workspace', 'docblockr:join', event => {
+      this.event = event;
       // console.log('Join command');
-      if (self.validateRequest({ scope: 'comment.block' })) { self.joinCommand(); }
+      if (this.validateRequest({ scope: 'comment.block' })) { this.joinCommand(); }
     });
 
-    global.atom.commands.add('atom-workspace', 'docblockr:reparse', function (event) {
-      self.event = event;
+    global.atom.commands.add('atom-workspace', 'docblockr:reparse', event => {
+      this.event = event;
       // console.log('Reparse command');
-      if (self.validateRequest({ scope: 'comment.block' })) { self.reparseCommand(); }
+      if (this.validateRequest({ scope: 'comment.block' })) { this.reparseCommand(); }
     });
 
-    global.atom.commands.add('atom-workspace', 'docblockr:wrap-lines', function (event) {
-      self.event = event;
+    global.atom.commands.add('atom-workspace', 'docblockr:wrap-lines', event => {
+      this.event = event;
       // console.log('Wraplines command');
-      if (self.validateRequest({ scope: 'comment.block' })) { self.wrapLinesCommand(); }
+      if (this.validateRequest({ scope: 'comment.block' })) { this.wrapLinesCommand(); }
     });
 
-    global.atom.commands.add('atom-workspace', 'docblockr:decorate', function (event) {
-      self.event = event;
+    global.atom.commands.add('atom-workspace', 'docblockr:decorate', event => {
+      this.event = event;
       // console.log('Decorate command');
-      if (self.validateRequest({ scope: 'comment.line.double-slash' })) { self.decorateCommand(); }
+      if (this.validateRequest({ scope: 'comment.line.double-slash' })) { this.decorateCommand(); }
     });
 
-    global.atom.commands.add('atom-workspace', 'docblockr:decorate-multiline', function (event) {
-      self.event = event;
+    global.atom.commands.add('atom-workspace', 'docblockr:decorate-multiline', event => {
+      this.event = event;
       // console.log('Decorate Multiline command');
-      if (self.validateRequest({ scope: 'comment.block' })) { self.decorateMultilineCommand(); }
+      if (this.validateRequest({ scope: 'comment.block' })) { this.decorateMultilineCommand(); }
     });
   }
 
@@ -225,9 +224,7 @@ class DocBlockrAtom {
 
     if (this.cursors.length > 0) {
       cursorPositions.splice(i, 1);
-      cursorPositions.forEach(function (value) {
-        value.destroy();
-      });
+      cursorPositions.forEach(value => value.destroy());
       return true;
     } else { return false; }
   }
@@ -335,9 +332,7 @@ class DocBlockrAtom {
     const editor = this.getRelevantEditor();
     const selections = editor.getSelections();
     let i, j, rowBegin;
-    const textWithEnding = function (row) {
-      return editor.buffer.lineForRow(row) + editor.buffer.lineEndingForRow(row);
-    };
+    const textWithEnding = row => editor.buffer.lineForRow(row) + editor.buffer.lineEndingForRow(row);
 
     for (i = 0; i < selections.length; i++) {
       const selection = selections[i];
@@ -433,23 +428,15 @@ class DocBlockrAtom {
 
     // last line
     lineText = editor.lineTextForBufferRow(scopeRange[1].row);
-    lineText = lineText.replace(/^(\s*)(\*)+\//, (function (self) {
-      return function (match, p1, stars) {
-        const len = stars.length;
-        return (p1 + self.repeat('*', (lineLength + 2 - len)) + '/' + '\n');
-      };
-    }(this)));
+    lineText = lineText.replace(/^(\s*)(\*)+\//, (match, p1, stars) =>
+      (p1 + this.repeat('*', (lineLength + 2 - stars.length)) + '/' + '\n'));
     let _range = [[scopeRange[1].row, 0], [scopeRange[1].row, lineLength]];
     editor.setTextInBufferRange(_range, lineText);
 
     // first line
     lineText = editor.lineTextForBufferRow(scopeRange[0].row);
-    lineText = lineText.replace(/^(\s*)\/(\*)+/, (function (self) {
-      return function (match, p1, stars) {
-        const len = stars.length;
-        return (p1 + '/' + self.repeat('*', (lineLength + 2 - len)));
-      };
-    }(this)));
+    lineText = lineText.replace(/^(\s*)\/(\*)+/, (match, p1, stars) =>
+      (p1 + '/' + this.repeat('*', (lineLength + 2 - stars.length))));
     _range = [[scopeRange[0].row, 0], [scopeRange[0].row, lineLength]];
     editor.setTextInBufferRange(_range, lineText);
 
@@ -481,9 +468,6 @@ class DocBlockrAtom {
   reparseCommand () {
     // Reparse a docblock to make the fields 'active' again, so that pressing tab will jump to the next one
     const tabIndex = this.counter();
-    const tabStop = function (m, g1) {
-      return `\${${tabIndex()}:${g1}}`;
-    };
     const editor = this.getRelevantEditor();
     const pos = editor.getCursorBufferPosition();
     // const Snippets = global.atom.packages.activePackages.snippets.mainModule;
@@ -497,7 +481,7 @@ class DocBlockrAtom {
     // strip out leading spaces, since inserting a snippet keeps the indentation
     text = text.replace(/\n\s+\*/g, '\n *');
     // replace [bracketed] [text] with a tabstop
-    text = text.replace(/(\[.+?\])/g, tabStop);
+    text = text.replace(/(\[.+?\])/g, (m, g1) => `\${${tabIndex()}:${g1}}`);
 
     editor.buffer.delete(([scopeRange[0], scopeRange[1]]));
     editor.setCursorBufferPosition(scopeRange[0]);
@@ -569,7 +553,7 @@ class DocBlockrAtom {
     // join all the lines, collapsing "empty" lines
     text = text.replace(/\n(\s*\*\s*\n)+/g, '\n\n');
 
-    const wrapPara = function (para) {
+    const wrapPara = para => {
       para = para.replace(/(\n|^)\s*\*\s*/g, ' ');
       let _i;
       // split the paragraph into words
@@ -706,9 +690,7 @@ class DocBlockrAtom {
 
   counter () {
     let count = 0;
-    return function () {
-      return ++count;
-    };
+    return () => ++count;
   }
 
   repeat (string, number) {
@@ -848,7 +830,7 @@ class DocBlockrAtom {
   }
 
   substituteVariables (out) {
-    function getConst (match, group, str) {
+    const getConst = (match, group, str) => {
       const varName = group;
       if (varName === 'datetime') {
         const datetime = new Date();
@@ -857,12 +839,9 @@ class DocBlockrAtom {
         const datetime = new Date();
         return datetime.toISOString().replace(/T.*/, '');
       } else { return match; }
-    }
-    function formatTime (datetime) {
-      function lengthFix (x) {
-        if (x < 10) { x = '0' + x; }
-        return x;
-      }
+    };
+    const formatTime = datetime => {
+      const lengthFix = x => `${x < 10 && '0'}${x}`;
       const hour = lengthFix(datetime.getHours());
       const min = lengthFix(datetime.getMinutes());
       const sec = lengthFix(datetime.getSeconds());
@@ -872,21 +851,16 @@ class DocBlockrAtom {
       tzString += lengthFix(Math.floor(Math.abs(tz)).toString()) + ((tz % 1) * 60);
       datetime = datetime.toISOString().replace(/T.*/, '');
       return (datetime += 'T' + hour + ':' + min + ':' + sec + tzString);
-    }
-    function subLine (line) {
-      const regex = /\{\{([^}]+)\}\}/g;
-      return line.replace(regex, getConst);
-    }
-    return out.map(subLine);
+    };
+
+    return out.map(line => line.replace(/\{\{([^}]+)\}\}/g, getConst));
   }
 
   alignTags (out) {
-    const outputWidth = function (str) {
-      // get the length of a string, after it is output as a snippet,
-      // "${1:foo}" --> 3
-      return str.replace(/[$][{]\d+:([^}]+)[}]/, '$1').replace('\\$', '$').length;
-    };
-      // count how many columns we have
+    // get the length of a string, after it is output as a snippet,
+    // "${1:foo}" --> 3
+    const outputWidth = str => str.replace(/[$][{]\d+:([^}]+)[}]/, '$1').replace('\\$', '$').length;
+    // count how many columns we have
     let maxCols = 0;
     // this is a 2d list of the widths per column per line
     const widths = [];
@@ -938,9 +912,7 @@ class DocBlockrAtom {
 
   fixTabStops (out) {
     const tabIndex = this.counter();
-    const swapTabs = function (match, group1, group2, str) {
-      return (group1 + tabIndex() + group2);
-    };
+    const swapTabs = (match, group1, group2, str) => (group1 + tabIndex() + group2);
     for (let i = 0; i < out.length; i++) { out[i] = out[i].replace(/(\$\{)\d+(:[^}]+\})/g, swapTabs); }
     return out;
   }

--- a/lib/docblockr.js
+++ b/lib/docblockr.js
@@ -100,9 +100,9 @@ module.exports = {
   },
 
   consumeSnippetsService: function (service) {
-    this.Docblockr.set_snippets_service(service);
+    this.Docblockr.setSnippetsService(service);
     return new Disposable(() => {
-      this.Docblockr.set_snippets_service(null);
+      this.Docblockr.setSnippetsService(null);
     });
   }
 };

--- a/lib/docsparser.js
+++ b/lib/docsparser.js
@@ -197,9 +197,7 @@ class DocsParser {
 
       // TODO
       // out.push(util.format(formatStr, formatArgs));
-      formatArgs.forEach(function (element) {
-        formatStr = util.format(formatStr, element);
-      });
+      formatArgs.forEach(element => (formatStr = util.format(formatStr, element)));
       out.push(formatStr);
     }
     const matchingNames = this.getMatchingNotations(name);
@@ -326,7 +324,7 @@ class DocsParser {
   }
 
   getMatchingNotations (name) {
-    const checkMatch = function (rule) {
+    const checkMatch = rule => {
       if (rule.indexOf('prefix') > -1) {
         // TODO :escape prefix
         let regex = new RegExp(rule.prefix);

--- a/lib/docsparser.js
+++ b/lib/docsparser.js
@@ -3,9 +3,9 @@ const escape = require('./utils').escape;
 
 class DocsParser {
   constructor (settings) {
-    this.editor_settings = settings;
-    this.setup_settings();
-    this.name_override = null;
+    this.editorSettings = settings;
+    this.setupSettings();
+    this.nameOverride = null;
   }
 
   init (viewSettings) {
@@ -14,24 +14,24 @@ class DocsParser {
     this.nameOverride = null;
   }
 
-  is_existing_comment (line) {
+  isExistingComment (line) {
     return /^\s*\*/.test(line);
   }
 
-  is_numeric (val) {
+  isNumeric (val) {
     return !isNaN(val);
   }
 
-  set_name_override (name) {
+  setNameOverride (name) {
     // overrides the description of the function - used instead of parsed description
-    this.name_override = name;
+    this.nameOverride = name;
   }
 
-  get_name_override () {
-    return this.name_override;
+  getNameOverride () {
+    return this.nameOverride;
   }
 
-  format_class (name) {
+  formatClass (name) {
     const out = [];
     const temp = `\${1:[${escape(name)} description]}`;
     out.push(temp);
@@ -39,27 +39,27 @@ class DocsParser {
   }
 
   parse (line) {
-    if (this.editor_settings.simple_mode || !line) {
+    if (this.editorSettings.simple_mode || !line) {
       return null;
     }
 
     let out;
-    out = this.parse_class && this.parse_class(line); // (name, extends)
+    out = this.parseClass && this.parseClass(line); // (name, extends)
     if (out) {
-      return this.format_class.apply(this, out);
+      return this.formatClass.apply(this, out);
     }
-    out = this.parse_function(line); // (name, args, retval, options)
+    out = this.parseFunction(line); // (name, args, retval, options)
     if (out) {
-      return this.format_function.apply(this, out);
+      return this.formatFunction.apply(this, out);
     }
-    out = this.parse_var(line); // (name, val, valType)
+    out = this.parseVar(line); // (name, val, valType)
     if (out) {
-      return this.format_var.apply(this, out);
+      return this.formatVar.apply(this, out);
     }
     return null;
   }
 
-  format_var (name, val, valType) {
+  formatVar (name, val, valType) {
     valType = typeof valType !== 'undefined' ? valType : null;
     const out = [];
     let braceOpen, braceClose, temp;
@@ -73,7 +73,7 @@ class DocsParser {
       if (!val || (val === '')) { // quick short circuit
         valType = '[type]';
       } else {
-        valType = this.guess_type_from_value(val) || this.guess_type_from_name(name) || '[type]';
+        valType = this.guessTypeFromValue(val) || this.guessTypeFromName(name) || '[type]';
       }
     }
     if (this.inline) {
@@ -91,7 +91,7 @@ class DocsParser {
     return out;
   }
 
-  get_typeInfo (argType, argName) {
+  geTypeInfo (argType, argName) {
     if (!this.settings.typeInfo) {
       return '';
     }
@@ -105,7 +105,7 @@ class DocsParser {
     }
 
     if (!argType) {
-      argType = this.guess_type_from_name(argName) || '[type]';
+      argType = this.guessTypeFromName(argName) || '[type]';
     }
     if (!argName) {
       argName = '[name]';
@@ -114,25 +114,25 @@ class DocsParser {
     return `${braceOpen}\${1:${escape(argType)}}${braceClose} `;
   }
 
-  format_function (name, args, retval, options) {
+  formatFunction (name, args, retval, options) {
     options = (typeof options !== 'undefined') ? options : {};
     let out = [];
     let i, formatStr;
-    if (Object.prototype.hasOwnProperty.call(options, 'as_setter')) {
+    if (Object.prototype.hasOwnProperty.call(options, 'asSetter')) {
       out.push('@private');
       return out;
     }
-    const extraTagAfter = this.editor_settings.extraTags_go_after || false;
+    const extraTagAfter = this.editorSettings.extra_tags_go_after || false;
 
-    const description = this.get_name_override() || ('[' + escape(name) + (name ? ' ' : '') + 'description]');
+    const description = this.getNameOverride() || ('[' + escape(name) + (name ? ' ' : '') + 'description]');
     out.push('${1:' + description + '}');
 
-    if (this.editor_settings.auto_add_method_tag) {
+    if (this.editorSettings.auto_add_method_tag) {
       out.push('@method ' + escape(name));
     }
 
     if (!extraTagAfter) {
-      out = this.add_extra_tags(out);
+      out = this.addExtraTags(out);
     }
 
     let typeInfo;
@@ -141,15 +141,15 @@ class DocsParser {
     if (args) {
       // remove comments inside the argument list.
       args = args.replace(/\/\*.*?\*\//, '');
-      const parsedArgs = this.parse_args(args);
+      const parsedArgs = this.parseArgs(args);
       for (i = 0; i < parsedArgs.length; i++) {
         const argType = parsedArgs[i][0];
         const argName = parsedArgs[i][1];
 
         if (this.settings.typeInfo) {
-          typeInfo = this.get_typeInfo(argType, argName);
+          typeInfo = this.geTypeInfo(argType, argName);
         }
-        if (this.editor_settings.param_description) {
+        if (this.editorSettings.param_description) {
           // define the string in two pieces to avoid lint complaints
           paramDescription = ' $' + '{1:[description]}';
         }
@@ -158,13 +158,13 @@ class DocsParser {
       }
     }
 
-    if (Object.prototype.hasOwnProperty.call(options, 'is_constructor') && options.is_constructor) {
+    if (Object.prototype.hasOwnProperty.call(options, 'isConstructor') && options.isConstructor) {
       out.push('@constructor');
     }
 
     // return value type might be already available in some languages but
     // even then ask language specific parser if it wants it listed
-    const retType = this.get_function_return_type(name, retval);
+    const retType = this.getFunctionReturnType(name, retval);
     if (retType !== null) {
       typeInfo = '';
       if (this.settings.typeInfo) {
@@ -176,17 +176,17 @@ class DocsParser {
       }
 
       const formatArgs = [
-        (this.editor_settings.return_tag || '@return'),
+        (this.editorSettings.return_tag || '@return'),
         typeInfo
       ];
 
-      if (this.editor_settings.return_description) {
+      if (this.editorSettings.return_description) {
         // define the string in two pieces to avoid lint complaints
         formatStr = '%s%s %s$' + '{1:[description]}';
         let thirdArg = '';
 
         // the extra space here is so that the description will align with the param description
-        if (args && this.editor_settings.align_tags === 'deep' && !this.editor_settings.per_section_indent) {
+        if (args && this.editorSettings.align_tags === 'deep' && !this.editorSettings.per_section_indent) {
           thirdArg = ' ';
         }
 
@@ -202,7 +202,7 @@ class DocsParser {
       });
       out.push(formatStr);
     }
-    const matchingNames = this.get_matching_notations(name);
+    const matchingNames = this.getMatchingNotations(name);
     for (i = 0; i < matchingNames.length; i++) {
       const notation = matchingNames[i];
       if (notation.indexOf('tags') > -1) {
@@ -210,12 +210,12 @@ class DocsParser {
       }
     }
 
-    if (extraTagAfter) { out = this.add_extra_tags(out); }
+    if (extraTagAfter) { out = this.addExtraTags(out); }
 
     return out;
   }
 
-  get_function_return_type (name, retval) {
+  getFunctionReturnType (name, retval) {
     // returns None for no return type. False meaning unknown, or a string
     if (/^[A-Z]/.test(name)) { return null; } // no return, but should add a class
 
@@ -229,10 +229,10 @@ class DocsParser {
       return this.settings.bool;
     }
 
-    return (this.guess_type_from_name(name) || false);
+    return (this.guessTypeFromName(name) || false);
   }
 
-  parse_args (args) {
+  parseArgs (args) {
     /*
       an array of tuples, the first being the best guess at the type, the second being the name
       */
@@ -289,8 +289,8 @@ class DocsParser {
 
     for (i = 0; i < blocks.length; i++) {
       const arg = blocks[i];
-      const name = this.get_arg_name(arg);
-      const type = this.get_arg_type(arg);
+      const name = this.getArgName(arg);
+      const type = this.getArgType(arg);
       if (name) {
         out.push([type, name]);
       }
@@ -298,22 +298,22 @@ class DocsParser {
     return out;
   }
 
-  get_arg_type (arg) {
+  getArgType (arg) {
     return null;
   }
 
-  get_arg_name (arg) {
+  getArgName (arg) {
     return arg;
   }
 
-  add_extra_tags (out) {
-    const extraTags = this.editor_settings.extraTags || [];
+  addExtraTags (out) {
+    const extraTags = this.editorSettings.extra_tags || [];
     if (extraTags.length > 0) { out = out.concat(extraTags); }
     return out;
   }
 
-  guess_type_from_name (name) {
-    const matches = this.get_matching_notations(name);
+  guessTypeFromName (name) {
+    const matches = this.getMatchingNotations(name);
     if (matches.length > 0) {
       const rule = matches[0];
       if (rule.indexOf('type') > -1) { return (this.settings.indexOf(rule.type) > -1) ? this.settings.rule.type : rule.type; }
@@ -325,7 +325,7 @@ class DocsParser {
     return false;
   }
 
-  get_matching_notations (name) {
+  getMatchingNotations (name) {
     const checkMatch = function (rule) {
       if (rule.indexOf('prefix') > -1) {
         // TODO :escape prefix
@@ -335,10 +335,10 @@ class DocsParser {
       } else if (rule.indexOf('regex') > -1) { return rule.regex.exec(name); }
     };
 
-    return (this.editor_settings.notation_map || []).filter(checkMatch);
+    return (this.editorSettings.notation_map || []).filter(checkMatch);
   }
 
-  get_definition (editor, pos, readLine) {
+  getDefinition (editor, pos, readLine) {
     const maxLines = 25;
 
     let definition = '';

--- a/lib/docsparser.js
+++ b/lib/docsparser.js
@@ -1,397 +1,397 @@
-'use strict';
-
 const util = require('util');
 const escape = require('./utils').escape;
 
-function DocsParser (settings) {
-  this.editor_settings = settings;
-  this.setup_settings();
-  this.name_override = null;
-}
-
-DocsParser.prototype.init = function (viewSettings) {
-  this.viewSettings = viewSettings;
-  this.setupSettings();
-  this.nameOverride = null;
-};
-
-DocsParser.prototype.is_existing_comment = function (line) {
-  return /^\s*\*/.test(line);
-};
-
-DocsParser.prototype.is_numeric = function (val) {
-  return !isNaN(val);
-};
-
-DocsParser.prototype.set_name_override = function (name) {
-  // overrides the description of the function - used instead of parsed description
-  this.name_override = name;
-};
-
-DocsParser.prototype.get_name_override = function () {
-  return this.name_override;
-};
-
-DocsParser.prototype.format_class = function (name) {
-  const out = [];
-  const temp = `\${1:[${escape(name)} description]}`;
-  out.push(temp);
-  return out;
-};
-
-DocsParser.prototype.parse = function (line) {
-  if (this.editor_settings.simple_mode || !line) {
-    return null;
+class DocsParser {
+  constructor (settings) {
+    this.editor_settings = settings;
+    this.setup_settings();
+    this.name_override = null;
   }
 
-  let out;
-  out = this.parse_class && this.parse_class(line); // (name, extends)
-  if (out) {
-    return this.format_class.apply(this, out);
+  init (viewSettings) {
+    this.viewSettings = viewSettings;
+    this.setupSettings();
+    this.nameOverride = null;
   }
-  out = this.parse_function(line); // (name, args, retval, options)
-  if (out) {
-    return this.format_function.apply(this, out);
-  }
-  out = this.parse_var(line); // (name, val, valType)
-  if (out) {
-    return this.format_var.apply(this, out);
-  }
-  return null;
-};
 
-DocsParser.prototype.format_var = function (name, val, valType) {
-  valType = typeof valType !== 'undefined' ? valType : null;
-  const out = [];
-  let braceOpen, braceClose, temp;
-  if (this.settings.curlyTypes) {
-    braceOpen = '{';
-    braceClose = '}';
-  } else {
-    braceOpen = braceClose = '';
+  is_existing_comment (line) {
+    return /^\s*\*/.test(line);
   }
-  if (!valType) {
-    if (!val || (val === '')) { // quick short circuit
-      valType = '[type]';
-    } else {
-      valType = this.guess_type_from_value(val) || this.guess_type_from_name(name) || '[type]';
-    }
+
+  is_numeric (val) {
+    return !isNaN(val);
   }
-  if (this.inline) {
-    temp = `@${this.settings.typeTag} ${braceOpen}\${1:${valType}}${braceClose} \${1:[description]}`;
+
+  set_name_override (name) {
+    // overrides the description of the function - used instead of parsed description
+    this.name_override = name;
+  }
+
+  get_name_override () {
+    return this.name_override;
+  }
+
+  format_class (name) {
+    const out = [];
+    const temp = `\${1:[${escape(name)} description]}`;
     out.push(temp);
-  } else {
-    temp = `\${1:[${escape(name)} description]}`;
-    out.push(temp);
-
-    if (this.settings.typeInfo) {
-      temp = `@${this.settings.typeTag} ${braceOpen}\${1:${valType}}${braceClose}`;
-      out.push(temp);
-    }
-  }
-  return out;
-};
-
-DocsParser.prototype.get_typeInfo = function (argType, argName) {
-  if (!this.settings.typeInfo) {
-    return '';
-  }
-
-  let braceOpen, braceClose;
-  if (this.settings.curlyTypes) {
-    braceOpen = '{';
-    braceClose = '}';
-  } else {
-    braceOpen = braceClose = '';
-  }
-
-  if (!argType) {
-    argType = this.guess_type_from_name(argName) || '[type]';
-  }
-  if (!argName) {
-    argName = '[name]';
-  }
-
-  return `${braceOpen}\${1:${escape(argType)}}${braceClose} `;
-};
-
-DocsParser.prototype.format_function = function (name, args, retval, options) {
-  options = (typeof options !== 'undefined') ? options : {};
-  let out = [];
-  let i, formatStr;
-  if (Object.prototype.hasOwnProperty.call(options, 'as_setter')) {
-    out.push('@private');
     return out;
   }
-  const extraTagAfter = this.editor_settings.extraTags_go_after || false;
 
-  const description = this.get_name_override() || ('[' + escape(name) + (name ? ' ' : '') + 'description]');
-  out.push('${1:' + description + '}');
-
-  if (this.editor_settings.auto_add_method_tag) {
-    out.push('@method ' + escape(name));
-  }
-
-  if (!extraTagAfter) {
-    out = this.add_extra_tags(out);
-  }
-
-  let typeInfo;
-  let paramDescription;
-  // if there are arguments, add a @param for each
-  if (args) {
-    // remove comments inside the argument list.
-    args = args.replace(/\/\*.*?\*\//, '');
-    const parsedArgs = this.parse_args(args);
-    for (i = 0; i < parsedArgs.length; i++) {
-      const argType = parsedArgs[i][0];
-      const argName = parsedArgs[i][1];
-
-      if (this.settings.typeInfo) {
-        typeInfo = this.get_typeInfo(argType, argName);
-      }
-      if (this.editor_settings.param_description) {
-        // define the string in two pieces to avoid lint complaints
-        paramDescription = ' $' + '{1:[description]}';
-      }
-
-      out.push(`@param ${typeInfo || ''}${escape(argName)} ${paramDescription || ''}`);
-    }
-  }
-
-  if (Object.prototype.hasOwnProperty.call(options, 'is_constructor') && options.is_constructor) {
-    out.push('@constructor');
-  }
-
-  // return value type might be already available in some languages but
-  // even then ask language specific parser if it wants it listed
-  const retType = this.get_function_return_type(name, retval);
-  if (retType !== null) {
-    typeInfo = '';
-    if (this.settings.typeInfo) {
-      if (this.settings.curlyTypes) {
-        typeInfo = ` {\${1:${retType || '[type]'}}}`;
-      } else {
-        typeInfo = ` \${1:${retType || '[type]'}}`;
-      }
+  parse (line) {
+    if (this.editor_settings.simple_mode || !line) {
+      return null;
     }
 
-    const formatArgs = [
-      (this.editor_settings.return_tag || '@return'),
-      typeInfo
-    ];
-
-    if (this.editor_settings.return_description) {
-      // define the string in two pieces to avoid lint complaints
-      formatStr = '%s%s %s$' + '{1:[description]}';
-      let thirdArg = '';
-
-      // the extra space here is so that the description will align with the param description
-      if (args && this.editor_settings.align_tags === 'deep' && !this.editor_settings.per_section_indent) {
-        thirdArg = ' ';
-      }
-
-      formatArgs.push(thirdArg);
-    } else {
-      formatStr = '%s%s';
+    let out;
+    out = this.parse_class && this.parse_class(line); // (name, extends)
+    if (out) {
+      return this.format_class.apply(this, out);
     }
-
-    // TODO
-    // out.push(util.format(formatStr, formatArgs));
-    formatArgs.forEach(function (element) {
-      formatStr = util.format(formatStr, element);
-    });
-    out.push(formatStr);
-  }
-  const matchingNames = this.get_matching_notations(name);
-  for (i = 0; i < matchingNames.length; i++) {
-    const notation = matchingNames[i];
-    if (notation.indexOf('tags') > -1) {
-      out.concat(notation.args);
+    out = this.parse_function(line); // (name, args, retval, options)
+    if (out) {
+      return this.format_function.apply(this, out);
     }
-  }
-
-  if (extraTagAfter) { out = this.add_extra_tags(out); }
-
-  return out;
-};
-
-DocsParser.prototype.get_function_return_type = function (name, retval) {
-  // returns None for no return type. False meaning unknown, or a string
-  if (/^[A-Z]/.test(name)) { return null; } // no return, but should add a class
-
-  if (name.search(/[$_]?(?:set|add)($|[A-Z_])/) > -1) {
-    // setter/mutator, no return
+    out = this.parse_var(line); // (name, val, valType)
+    if (out) {
+      return this.format_var.apply(this, out);
+    }
     return null;
   }
 
-  if (name.search(/[$_]?(?:is|has)($|[A-Z_])/) > -1) {
-    // functions starting with 'is' or 'has'
-    return this.settings.bool;
-  }
-
-  return (this.guess_type_from_name(name) || false);
-};
-
-DocsParser.prototype.parse_args = function (args) {
-  /*
-    an array of tuples, the first being the best guess at the type, the second being the name
-    */
-  const out = [];
-  if (!args) { return out; }
-  // the current token
-  let current = '';
-  // characters which open a section inside which commas are not separators between different arguments
-  const openQuotes = '"\'<(';
-  // characters which close the the section. The position of the character here should match the opening
-  // indicator in `openQuotes`
-  const closeQuotes = '"\'>)';
-  let matchingQuote = '';
-  let insideQuotes = false;
-  let nextIsLiteral = false;
-  const blocks = [];
-  // This flag indicates if current character position is following an
-  // opening `[`
-  let inArray = 0;
-  let i;
-  for (i = 0; i < args.length; i++) {
-    const character = args.charAt(i);
-    if (nextIsLiteral) { // previous char was a \
-      current += character;
-      nextIsLiteral = false;
-    } else if (character === '\\') {
-      nextIsLiteral = true;
-    } else if (insideQuotes) {
-      current += character;
-      if (character === matchingQuote) { insideQuotes = false; }
+  format_var (name, val, valType) {
+    valType = typeof valType !== 'undefined' ? valType : null;
+    const out = [];
+    let braceOpen, braceClose, temp;
+    if (this.settings.curlyTypes) {
+      braceOpen = '{';
+      braceClose = '}';
     } else {
-      if (character === ',' && !inArray) {
-        blocks.push(current.trim());
-        current = '';
+      braceOpen = braceClose = '';
+    }
+    if (!valType) {
+      if (!val || (val === '')) { // quick short circuit
+        valType = '[type]';
       } else {
-        // Following a `[` character indicate that the proceeding
-        // characters are array values
-        if (character === '[') {
-          inArray++;
-        } else if (character === ']') {
-          inArray--;
+        valType = this.guess_type_from_value(val) || this.guess_type_from_name(name) || '[type]';
+      }
+    }
+    if (this.inline) {
+      temp = `@${this.settings.typeTag} ${braceOpen}\${1:${valType}}${braceClose} \${1:[description]}`;
+      out.push(temp);
+    } else {
+      temp = `\${1:[${escape(name)} description]}`;
+      out.push(temp);
+
+      if (this.settings.typeInfo) {
+        temp = `@${this.settings.typeTag} ${braceOpen}\${1:${valType}}${braceClose}`;
+        out.push(temp);
+      }
+    }
+    return out;
+  }
+
+  get_typeInfo (argType, argName) {
+    if (!this.settings.typeInfo) {
+      return '';
+    }
+
+    let braceOpen, braceClose;
+    if (this.settings.curlyTypes) {
+      braceOpen = '{';
+      braceClose = '}';
+    } else {
+      braceOpen = braceClose = '';
+    }
+
+    if (!argType) {
+      argType = this.guess_type_from_name(argName) || '[type]';
+    }
+    if (!argName) {
+      argName = '[name]';
+    }
+
+    return `${braceOpen}\${1:${escape(argType)}}${braceClose} `;
+  }
+
+  format_function (name, args, retval, options) {
+    options = (typeof options !== 'undefined') ? options : {};
+    let out = [];
+    let i, formatStr;
+    if (Object.prototype.hasOwnProperty.call(options, 'as_setter')) {
+      out.push('@private');
+      return out;
+    }
+    const extraTagAfter = this.editor_settings.extraTags_go_after || false;
+
+    const description = this.get_name_override() || ('[' + escape(name) + (name ? ' ' : '') + 'description]');
+    out.push('${1:' + description + '}');
+
+    if (this.editor_settings.auto_add_method_tag) {
+      out.push('@method ' + escape(name));
+    }
+
+    if (!extraTagAfter) {
+      out = this.add_extra_tags(out);
+    }
+
+    let typeInfo;
+    let paramDescription;
+    // if there are arguments, add a @param for each
+    if (args) {
+      // remove comments inside the argument list.
+      args = args.replace(/\/\*.*?\*\//, '');
+      const parsedArgs = this.parse_args(args);
+      for (i = 0; i < parsedArgs.length; i++) {
+        const argType = parsedArgs[i][0];
+        const argName = parsedArgs[i][1];
+
+        if (this.settings.typeInfo) {
+          typeInfo = this.get_typeInfo(argType, argName);
         }
+        if (this.editor_settings.param_description) {
+          // define the string in two pieces to avoid lint complaints
+          paramDescription = ' $' + '{1:[description]}';
+        }
+
+        out.push(`@param ${typeInfo || ''}${escape(argName)} ${paramDescription || ''}`);
+      }
+    }
+
+    if (Object.prototype.hasOwnProperty.call(options, 'is_constructor') && options.is_constructor) {
+      out.push('@constructor');
+    }
+
+    // return value type might be already available in some languages but
+    // even then ask language specific parser if it wants it listed
+    const retType = this.get_function_return_type(name, retval);
+    if (retType !== null) {
+      typeInfo = '';
+      if (this.settings.typeInfo) {
+        if (this.settings.curlyTypes) {
+          typeInfo = ` {\${1:${retType || '[type]'}}}`;
+        } else {
+          typeInfo = ` \${1:${retType || '[type]'}}`;
+        }
+      }
+
+      const formatArgs = [
+        (this.editor_settings.return_tag || '@return'),
+        typeInfo
+      ];
+
+      if (this.editor_settings.return_description) {
+        // define the string in two pieces to avoid lint complaints
+        formatStr = '%s%s %s$' + '{1:[description]}';
+        let thirdArg = '';
+
+        // the extra space here is so that the description will align with the param description
+        if (args && this.editor_settings.align_tags === 'deep' && !this.editor_settings.per_section_indent) {
+          thirdArg = ' ';
+        }
+
+        formatArgs.push(thirdArg);
+      } else {
+        formatStr = '%s%s';
+      }
+
+      // TODO
+      // out.push(util.format(formatStr, formatArgs));
+      formatArgs.forEach(function (element) {
+        formatStr = util.format(formatStr, element);
+      });
+      out.push(formatStr);
+    }
+    const matchingNames = this.get_matching_notations(name);
+    for (i = 0; i < matchingNames.length; i++) {
+      const notation = matchingNames[i];
+      if (notation.indexOf('tags') > -1) {
+        out.concat(notation.args);
+      }
+    }
+
+    if (extraTagAfter) { out = this.add_extra_tags(out); }
+
+    return out;
+  }
+
+  get_function_return_type (name, retval) {
+    // returns None for no return type. False meaning unknown, or a string
+    if (/^[A-Z]/.test(name)) { return null; } // no return, but should add a class
+
+    if (name.search(/[$_]?(?:set|add)($|[A-Z_])/) > -1) {
+      // setter/mutator, no return
+      return null;
+    }
+
+    if (name.search(/[$_]?(?:is|has)($|[A-Z_])/) > -1) {
+      // functions starting with 'is' or 'has'
+      return this.settings.bool;
+    }
+
+    return (this.guess_type_from_name(name) || false);
+  }
+
+  parse_args (args) {
+    /*
+      an array of tuples, the first being the best guess at the type, the second being the name
+      */
+    const out = [];
+    if (!args) { return out; }
+    // the current token
+    let current = '';
+    // characters which open a section inside which commas are not separators between different arguments
+    const openQuotes = '"\'<(';
+    // characters which close the the section. The position of the character here should match the opening
+    // indicator in `openQuotes`
+    const closeQuotes = '"\'>)';
+    let matchingQuote = '';
+    let insideQuotes = false;
+    let nextIsLiteral = false;
+    const blocks = [];
+    // This flag indicates if current character position is following an
+    // opening `[`
+    let inArray = 0;
+    let i;
+    for (i = 0; i < args.length; i++) {
+      const character = args.charAt(i);
+      if (nextIsLiteral) { // previous char was a \
         current += character;
-        const quoteIndex = openQuotes.indexOf(character);
-        if (quoteIndex > -1) {
-          matchingQuote = closeQuotes[quoteIndex];
-          insideQuotes = true;
+        nextIsLiteral = false;
+      } else if (character === '\\') {
+        nextIsLiteral = true;
+      } else if (insideQuotes) {
+        current += character;
+        if (character === matchingQuote) { insideQuotes = false; }
+      } else {
+        if (character === ',' && !inArray) {
+          blocks.push(current.trim());
+          current = '';
+        } else {
+          // Following a `[` character indicate that the proceeding
+          // characters are array values
+          if (character === '[') {
+            inArray++;
+          } else if (character === ']') {
+            inArray--;
+          }
+          current += character;
+          const quoteIndex = openQuotes.indexOf(character);
+          if (quoteIndex > -1) {
+            matchingQuote = closeQuotes[quoteIndex];
+            insideQuotes = true;
+          }
         }
       }
     }
-  }
 
-  blocks.push(current.trim());
+    blocks.push(current.trim());
 
-  for (i = 0; i < blocks.length; i++) {
-    const arg = blocks[i];
-    const name = this.get_arg_name(arg);
-    const type = this.get_arg_type(arg);
-    if (name) {
-      out.push([type, name]);
+    for (i = 0; i < blocks.length; i++) {
+      const arg = blocks[i];
+      const name = this.get_arg_name(arg);
+      const type = this.get_arg_type(arg);
+      if (name) {
+        out.push([type, name]);
+      }
     }
+    return out;
   }
-  return out;
-};
 
-DocsParser.prototype.get_arg_type = function (arg) {
-  return null;
-};
-
-DocsParser.prototype.get_arg_name = function (arg) {
-  return arg;
-};
-
-DocsParser.prototype.add_extra_tags = function (out) {
-  const extraTags = this.editor_settings.extraTags || [];
-  if (extraTags.length > 0) { out = out.concat(extraTags); }
-  return out;
-};
-
-DocsParser.prototype.guess_type_from_name = function (name) {
-  const matches = this.get_matching_notations(name);
-  if (matches.length > 0) {
-    const rule = matches[0];
-    if (rule.indexOf('type') > -1) { return (this.settings.indexOf(rule.type) > -1) ? this.settings.rule.type : rule.type; }
+  get_arg_type (arg) {
+    return null;
   }
-  if (name.search('(?:is|has)[A-Z_]') > -1) { return this.settings.bool; }
 
-  if (name.search('^(?:cb|callback|done|next|fn)$') > -1) { return this.settings.function; }
+  get_arg_name (arg) {
+    return arg;
+  }
 
-  return false;
-};
+  add_extra_tags (out) {
+    const extraTags = this.editor_settings.extraTags || [];
+    if (extraTags.length > 0) { out = out.concat(extraTags); }
+    return out;
+  }
 
-DocsParser.prototype.get_matching_notations = function (name) {
-  const checkMatch = function (rule) {
-    if (rule.indexOf('prefix') > -1) {
-      // TODO :escape prefix
-      let regex = new RegExp(rule.prefix);
-      if (rule.prefix.search('.*[a-z]') > -1) { regex = new RegExp(regex.source + (/(?:[A-Z_]|$)/).source); }
-      return regex.exec(name);
-    } else if (rule.indexOf('regex') > -1) { return rule.regex.exec(name); }
-  };
-
-  return (this.editor_settings.notation_map || []).filter(checkMatch);
-};
-
-DocsParser.prototype.get_definition = function (editor, pos, readLine) {
-  const maxLines = 25;
-
-  let definition = '';
-  let openBrackets = 0;
-
-  let line, match, char;
-  for (let i = 0; i < maxLines; i++) {
-    line = readLine(editor, pos);
-    pos.row += 1;
-
-    // null, undefined or invaild
-    if (typeof line !== 'string') {
-      break;
+  guess_type_from_name (name) {
+    const matches = this.get_matching_notations(name);
+    if (matches.length > 0) {
+      const rule = matches[0];
+      if (rule.indexOf('type') > -1) { return (this.settings.indexOf(rule.type) > -1) ? this.settings.rule.type : rule.type; }
     }
+    if (name.search('(?:is|has)[A-Z_]') > -1) { return this.settings.bool; }
 
-    line = line
-    // strip one line comments
-      .replace(/\/\/.*$/g, '')
-    // strip block comments
-      .replace(/\/\*.*\*\//g, '');
+    if (name.search('^(?:cb|callback|done|next|fn)$') > -1) { return this.settings.function; }
 
-    // ignore everything in front of the actual function
-    if (definition === '' && this.settings.fnOpener) {
-      match = RegExp(this.settings.fnOpener).exec(line);
+    return false;
+  }
 
-      if (match) {
-        line = line.slice(match.index);
+  get_matching_notations (name) {
+    const checkMatch = function (rule) {
+      if (rule.indexOf('prefix') > -1) {
+        // TODO :escape prefix
+        let regex = new RegExp(rule.prefix);
+        if (rule.prefix.search('.*[a-z]') > -1) { regex = new RegExp(regex.source + (/(?:[A-Z_]|$)/).source); }
+        return regex.exec(name);
+      } else if (rule.indexOf('regex') > -1) { return rule.regex.exec(name); }
+    };
+
+    return (this.editor_settings.notation_map || []).filter(checkMatch);
+  }
+
+  get_definition (editor, pos, readLine) {
+    const maxLines = 25;
+
+    let definition = '';
+    let openBrackets = 0;
+
+    let line, match, char;
+    for (let i = 0; i < maxLines; i++) {
+      line = readLine(editor, pos);
+      pos.row += 1;
+
+      // null, undefined or invaild
+      if (typeof line !== 'string') {
+        break;
+      }
+
+      line = line
+      // strip one line comments
+        .replace(/\/\/.*$/g, '')
+      // strip block comments
+        .replace(/\/\*.*\*\//g, '');
+
+      // ignore everything in front of the actual function
+      if (definition === '' && this.settings.fnOpener) {
+        match = RegExp(this.settings.fnOpener).exec(line);
+
+        if (match) {
+          line = line.slice(match.index);
+        }
+      }
+
+      // strip strings
+      // const searchForBrackets = line
+      //   .replace(/'(?:(\\.)|[^'])*'/g, '')
+      //   .replace(/"(?:\\.|[^"])*"/g, '');
+
+      for (char of line) {
+        switch (char) {
+          case '(': openBrackets++; break;
+          case ')': openBrackets--; break;
+        }
+      }
+
+      if (!/^\s*$/.exec(line)) {
+        definition += line;
+      }
+
+      if (openBrackets < 0) {
+        break;
       }
     }
 
-    // strip strings
-    // const searchForBrackets = line
-    //   .replace(/'(?:(\\.)|[^'])*'/g, '')
-    //   .replace(/"(?:\\.|[^"])*"/g, '');
-
-    for (char of line) {
-      switch (char) {
-        case '(': openBrackets++; break;
-        case ')': openBrackets--; break;
-      }
-    }
-
-    if (!/^\s*$/.exec(line)) {
-      definition += line;
-    }
-
-    if (openBrackets < 0) {
-      break;
-    }
+    return definition;
   }
-
-  return definition;
-};
+}
 
 module.exports = DocsParser;

--- a/lib/languages/actionscript.js
+++ b/lib/languages/actionscript.js
@@ -1,66 +1,64 @@
 const DocsParser = require('../docsparser');
 const xregexp = require('xregexp');
 
-class ActionscriptParser extends DocsParser {}
-
-ActionscriptParser.prototype.setup_settings = function () {
-  const nameToken = '[a-zA-Z_][a-zA-Z0-9_]*';
-  this.settings = {
-    commentType: 'block',
-    typeInfo: false,
-    curlyTypes: false,
-    typeTag: '',
-    commentCloser: ' */',
-    fnIdentifier: nameToken,
-    varIdentifier: `(${nameToken})(?::${nameToken})?`,
-    fnOpener: 'function(?:\\s+[gs]et)?(?:\\s+' + nameToken + ')?\\s*\\(',
-    bool: 'bool',
-    function: 'function'
-  };
-};
-
-ActionscriptParser.prototype.parse_function = function (line) {
-  let regex = xregexp(
-    // fnName = function,  fnName : function
-    '(?:(?P<name1>' + this.settings.varIdentifier + ')\\s*[:=]\\s*)?' +
-        'function(?:\\s+(?P<getset>[gs]et))?' +
-        // function fnName
-        '(?:\\s+(?P<name2>' + this.settings.fnIdentifier + '))?' +
-        // (arg1, arg2)
-        '\\s*\\(\\s*(?P<args>.*?)\\)'
-  );
-  const matches = xregexp.exec(line, regex);
-  if (matches === null) { return null; }
-
-  regex = new RegExp(this.settings.varIdentifier, 'g');
-  const name = matches.name1 || matches.name2 || '';
-  const args = matches.args;
-  const options = {};
-  if (matches.getset === 'set') { options.as_setter = true; }
-
-  return [name, args, null, options];
-};
-
-ActionscriptParser.prototype.parse_var = function (line) {
-  return null;
-};
-
-ActionscriptParser.prototype.get_arg_name = function (arg) {
-  if (!arg) {
-    return arg;
+module.exports = class ActionscriptParser extends DocsParser {
+  setup_settings () {
+    const nameToken = '[a-zA-Z_][a-zA-Z0-9_]*';
+    this.settings = {
+      commentType: 'block',
+      typeInfo: false,
+      curlyTypes: false,
+      typeTag: '',
+      commentCloser: ' */',
+      fnIdentifier: nameToken,
+      varIdentifier: `(${nameToken})(?::${nameToken})?`,
+      fnOpener: 'function(?:\\s+[gs]et)?(?:\\s+' + nameToken + ')?\\s*\\(',
+      bool: 'bool',
+      function: 'function'
+    };
   }
-  const regex = new RegExp(this.settings.varIdentifier + '(\\s*=.*)?');
-  const match = arg.match(regex);
-  if (match && match[1]) {
-    return match[1];
-  } else {
-    return arg;
+
+  parse_function (line) {
+    let regex = xregexp(
+      // fnName = function,  fnName : function
+      '(?:(?P<name1>' + this.settings.varIdentifier + ')\\s*[:=]\\s*)?' +
+          'function(?:\\s+(?P<getset>[gs]et))?' +
+          // function fnName
+          '(?:\\s+(?P<name2>' + this.settings.fnIdentifier + '))?' +
+          // (arg1, arg2)
+          '\\s*\\(\\s*(?P<args>.*?)\\)'
+    );
+    const matches = xregexp.exec(line, regex);
+    if (matches === null) { return null; }
+
+    regex = new RegExp(this.settings.varIdentifier, 'g');
+    const name = matches.name1 || matches.name2 || '';
+    const args = matches.args;
+    const options = {};
+    if (matches.getset === 'set') { options.as_setter = true; }
+
+    return [name, args, null, options];
+  }
+
+  parse_var (line) {
+    return null;
+  }
+
+  get_arg_name (arg) {
+    if (!arg) {
+      return arg;
+    }
+    const regex = new RegExp(this.settings.varIdentifier + '(\\s*=.*)?');
+    const match = arg.match(regex);
+    if (match && match[1]) {
+      return match[1];
+    } else {
+      return arg;
+    }
+  }
+
+  get_arg_type (arg) {
+    // could actually figure it out easily, but it's not important for the documentation
+    return null;
   }
 };
-
-ActionscriptParser.prototype.get_arg_type = function (arg) {
-  // could actually figure it out easily, but it's not important for the documentation
-  return null;
-};
-
-module.exports = ActionscriptParser;

--- a/lib/languages/actionscript.js
+++ b/lib/languages/actionscript.js
@@ -2,7 +2,7 @@ const DocsParser = require('../docsparser');
 const xregexp = require('xregexp');
 
 module.exports = class ActionscriptParser extends DocsParser {
-  setup_settings () {
+  setupSettings () {
     const nameToken = '[a-zA-Z_][a-zA-Z0-9_]*';
     this.settings = {
       commentType: 'block',
@@ -18,7 +18,7 @@ module.exports = class ActionscriptParser extends DocsParser {
     };
   }
 
-  parse_function (line) {
+  parseFunction (line) {
     let regex = xregexp(
       // fnName = function,  fnName : function
       '(?:(?P<name1>' + this.settings.varIdentifier + ')\\s*[:=]\\s*)?' +
@@ -35,16 +35,16 @@ module.exports = class ActionscriptParser extends DocsParser {
     const name = matches.name1 || matches.name2 || '';
     const args = matches.args;
     const options = {};
-    if (matches.getset === 'set') { options.as_setter = true; }
+    if (matches.getset === 'set') { options.asSetter = true; }
 
     return [name, args, null, options];
   }
 
-  parse_var (line) {
+  parseVar (line) {
     return null;
   }
 
-  get_arg_name (arg) {
+  getArgName (arg) {
     if (!arg) {
       return arg;
     }
@@ -57,7 +57,7 @@ module.exports = class ActionscriptParser extends DocsParser {
     }
   }
 
-  get_arg_type (arg) {
+  getArgType (arg) {
     // could actually figure it out easily, but it's not important for the documentation
     return null;
   }

--- a/lib/languages/actionscript.js
+++ b/lib/languages/actionscript.js
@@ -1,11 +1,7 @@
 const DocsParser = require('../docsparser');
 const xregexp = require('xregexp');
 
-function ActionscriptParser (settings) {
-  DocsParser.call(this, settings);
-}
-
-ActionscriptParser.prototype = Object.create(DocsParser.prototype);
+class ActionscriptParser extends DocsParser {}
 
 ActionscriptParser.prototype.setup_settings = function () {
   const nameToken = '[a-zA-Z_][a-zA-Z0-9_]*';

--- a/lib/languages/coffee.js
+++ b/lib/languages/coffee.js
@@ -1,77 +1,75 @@
 const DocsParser = require('../docsparser');
 const xregexp = require('xregexp');
 
-class CoffeeParser extends DocsParser {}
-
-CoffeeParser.prototype.setup_settings = function () {
-  const identifier = '[a-zA-Z_$][a-zA-Z_$0-9]*';
-  this.settings = {
-    commentType: 'block',
-    // curly brackets around the type information
-    curlyTypes: true,
-    typeTag: this.editor_settings.override_js_var || 'type',
-    typeInfo: true,
-    // technically, they can contain all sorts of unicode, but w/e
-    varIdentifier: identifier,
-    fnIdentifier: identifier,
-    fnOpener: null, // no multi-line function definitions for you, hipsters!
-    commentCloser: '###',
-    bool: 'Boolean',
-    function: 'Function'
-  };
-};
-
-CoffeeParser.prototype.parse_function = function (line) {
-  const regex = xregexp(
-    // fnName = function,  fnName : function
-    '(?:(?P<name>' + this.settings.varIdentifier + ')\\s*[:=]\\s*)?' +
-        '(?:\\((?P<args>[^()]*?)\\))?\\s*([=-]>)'
-  );
-  const matches = xregexp.exec(line, regex);
-  if (matches === null) { return null; }
-
-  // grab the name out of "name1 = function name2(foo)" preferring name1
-  const name = matches.name || '';
-  const args = matches.args;
-
-  return [name, args, null];
-};
-
-CoffeeParser.prototype.parse_var = function (line) {
-  //   const foo = blah,
-  //       foo = blah;
-  //   baz.foo = blah;
-  //   baz = {
-  //        foo : blah
-  //   }
-  const regex = xregexp(
-    '(?P<name>' + this.settings.varIdentifier + ')\\s*[=:]\\s*(?P<val>.*?)(?:[;,]|$)'
-  );
-  const matches = xregexp.exec(line, regex);
-  if (matches === null) { return null; }
-
-  return [matches.name, matches.val.trim()];
-};
-
-CoffeeParser.prototype.guess_type_from_value = function (val) {
-  const lowerPrimitives = this.editor_settings.lower_case_primitives || false;
-  if (this.is_numeric(val)) { return (lowerPrimitives ? 'number' : 'Number'); }
-  if ((val[0] === '"') || (val[0] === '\'')) { return (lowerPrimitives ? 'string' : 'String'); }
-  if (val[0] === '[') { return 'Array'; }
-  if (val[0] === '{') { return 'Object'; }
-  if ((val === 'true') || (val === 'false')) { return (lowerPrimitives ? 'boolean' : 'Boolean'); }
-  let regex = new RegExp('RegExp\\b|\\/[^\\/]');
-  if (regex.test(val)) {
-    return 'RegExp';
+module.exports = class CoffeeParser extends DocsParser {
+  setup_settings () {
+    const identifier = '[a-zA-Z_$][a-zA-Z_$0-9]*';
+    this.settings = {
+      commentType: 'block',
+      // curly brackets around the type information
+      curlyTypes: true,
+      typeTag: this.editor_settings.override_js_var || 'type',
+      typeInfo: true,
+      // technically, they can contain all sorts of unicode, but w/e
+      varIdentifier: identifier,
+      fnIdentifier: identifier,
+      fnOpener: null, // no multi-line function definitions for you, hipsters!
+      commentCloser: '###',
+      bool: 'Boolean',
+      function: 'Function'
+    };
   }
-  if (val.slice(0, 4) === 'new ') {
-    regex = new RegExp(
-      'new (' + this.settings.fnIdentifier + ')'
+
+  parse_function (line) {
+    const regex = xregexp(
+      // fnName = function,  fnName : function
+      '(?:(?P<name>' + this.settings.varIdentifier + ')\\s*[:=]\\s*)?' +
+          '(?:\\((?P<args>[^()]*?)\\))?\\s*([=-]>)'
     );
-    const matches = regex.exec(val);
-    return (matches[0] && matches[1]) || null;
-  }
-  return null;
-};
+    const matches = xregexp.exec(line, regex);
+    if (matches === null) { return null; }
 
-module.exports = CoffeeParser;
+    // grab the name out of "name1 = function name2(foo)" preferring name1
+    const name = matches.name || '';
+    const args = matches.args;
+
+    return [name, args, null];
+  }
+
+  parse_var (line) {
+    //   const foo = blah,
+    //       foo = blah;
+    //   baz.foo = blah;
+    //   baz = {
+    //        foo : blah
+    //   }
+    const regex = xregexp(
+      '(?P<name>' + this.settings.varIdentifier + ')\\s*[=:]\\s*(?P<val>.*?)(?:[;,]|$)'
+    );
+    const matches = xregexp.exec(line, regex);
+    if (matches === null) { return null; }
+
+    return [matches.name, matches.val.trim()];
+  }
+
+  guess_type_from_value (val) {
+    const lowerPrimitives = this.editor_settings.lower_case_primitives || false;
+    if (this.is_numeric(val)) { return (lowerPrimitives ? 'number' : 'Number'); }
+    if ((val[0] === '"') || (val[0] === '\'')) { return (lowerPrimitives ? 'string' : 'String'); }
+    if (val[0] === '[') { return 'Array'; }
+    if (val[0] === '{') { return 'Object'; }
+    if ((val === 'true') || (val === 'false')) { return (lowerPrimitives ? 'boolean' : 'Boolean'); }
+    let regex = new RegExp('RegExp\\b|\\/[^\\/]');
+    if (regex.test(val)) {
+      return 'RegExp';
+    }
+    if (val.slice(0, 4) === 'new ') {
+      regex = new RegExp(
+        'new (' + this.settings.fnIdentifier + ')'
+      );
+      const matches = regex.exec(val);
+      return (matches[0] && matches[1]) || null;
+    }
+    return null;
+  }
+};

--- a/lib/languages/coffee.js
+++ b/lib/languages/coffee.js
@@ -2,13 +2,13 @@ const DocsParser = require('../docsparser');
 const xregexp = require('xregexp');
 
 module.exports = class CoffeeParser extends DocsParser {
-  setup_settings () {
+  setupSettings () {
     const identifier = '[a-zA-Z_$][a-zA-Z_$0-9]*';
     this.settings = {
       commentType: 'block',
       // curly brackets around the type information
       curlyTypes: true,
-      typeTag: this.editor_settings.override_js_var || 'type',
+      typeTag: this.editorSettings.override_js_var || 'type',
       typeInfo: true,
       // technically, they can contain all sorts of unicode, but w/e
       varIdentifier: identifier,
@@ -20,7 +20,7 @@ module.exports = class CoffeeParser extends DocsParser {
     };
   }
 
-  parse_function (line) {
+  parseFunction (line) {
     const regex = xregexp(
       // fnName = function,  fnName : function
       '(?:(?P<name>' + this.settings.varIdentifier + ')\\s*[:=]\\s*)?' +
@@ -36,7 +36,7 @@ module.exports = class CoffeeParser extends DocsParser {
     return [name, args, null];
   }
 
-  parse_var (line) {
+  parseVar (line) {
     //   const foo = blah,
     //       foo = blah;
     //   baz.foo = blah;
@@ -52,9 +52,9 @@ module.exports = class CoffeeParser extends DocsParser {
     return [matches.name, matches.val.trim()];
   }
 
-  guess_type_from_value (val) {
-    const lowerPrimitives = this.editor_settings.lower_case_primitives || false;
-    if (this.is_numeric(val)) { return (lowerPrimitives ? 'number' : 'Number'); }
+  guessTypeFromValue (val) {
+    const lowerPrimitives = this.editorSettings.lower_case_primitives || false;
+    if (this.isNumeric(val)) { return (lowerPrimitives ? 'number' : 'Number'); }
     if ((val[0] === '"') || (val[0] === '\'')) { return (lowerPrimitives ? 'string' : 'String'); }
     if (val[0] === '[') { return 'Array'; }
     if (val[0] === '{') { return 'Object'; }

--- a/lib/languages/coffee.js
+++ b/lib/languages/coffee.js
@@ -1,11 +1,7 @@
 const DocsParser = require('../docsparser');
 const xregexp = require('xregexp');
 
-function CoffeeParser (settings) {
-  DocsParser.call(this, settings);
-}
-
-CoffeeParser.prototype = Object.create(DocsParser.prototype);
+class CoffeeParser extends DocsParser {}
 
 CoffeeParser.prototype.setup_settings = function () {
   const identifier = '[a-zA-Z_$][a-zA-Z_$0-9]*';

--- a/lib/languages/cpp.js
+++ b/lib/languages/cpp.js
@@ -3,7 +3,7 @@ const xregexp = require('xregexp');
 const util = require('util');
 
 module.exports = class CppParser extends DocsParser {
-  setup_settings () {
+  setupSettings () {
     const nameToken = '[a-zA-Z_][a-zA-Z0-9_]*';
     const identifier = util.format('(%s)(::%s)?(<%s>)?', nameToken, nameToken, nameToken);
     this.settings = {
@@ -20,7 +20,7 @@ module.exports = class CppParser extends DocsParser {
     };
   }
 
-  parse_function (line) {
+  parseFunction (line) {
     const regex = xregexp(
       '((?P<retval>' + this.settings.varIdentifier + ')[&*\\s]+)?' +
           '(?P<name>' + this.settings.varIdentifier + ');?' +
@@ -40,12 +40,12 @@ module.exports = class CppParser extends DocsParser {
     return [matches.name, args, retval];
   }
 
-  parse_args (args) {
+  parseArgs (args) {
     if (args.trim() === 'void') { return []; }
-    return super.parse_args(args);
+    return super.parseArgs(args);
   }
 
-  get_arg_type (arg) {
+  getArgType (arg) {
     if (arg === '...') {
       // variable arguments
       return 'VARARGS';
@@ -59,7 +59,7 @@ module.exports = class CppParser extends DocsParser {
     return result + arrayResult;
   }
 
-  get_arg_name (arg) {
+  getArgName (arg) {
     if (arg === '...') {
       // variable arguments
       return 'VARARGS';
@@ -69,15 +69,15 @@ module.exports = class CppParser extends DocsParser {
     return matches[1] || '[name]';
   }
 
-  parse_var (line) {
+  parseVar (line) {
     return null;
   }
 
-  guess_type_from_value (val) {
+  guessTypeFromValue (val) {
     return null;
   }
 
-  get_function_return_type (name, retval) {
+  getFunctionReturnType (name, retval) {
     return ((retval !== 'void') ? retval : null);
   }
 };

--- a/lib/languages/cpp.js
+++ b/lib/languages/cpp.js
@@ -2,85 +2,82 @@ const DocsParser = require('../docsparser');
 const xregexp = require('xregexp');
 const util = require('util');
 
-class CppParser extends DocsParser {}
+module.exports = class CppParser extends DocsParser {
+  setup_settings () {
+    const nameToken = '[a-zA-Z_][a-zA-Z0-9_]*';
+    const identifier = util.format('(%s)(::%s)?(<%s>)?', nameToken, nameToken, nameToken);
+    this.settings = {
+      commentType: 'block',
+      typeInfo: false,
+      curlyTypes: false,
+      typeTag: 'param',
+      commentCloser: ' */',
+      fnIdentifier: identifier,
+      varIdentifier: '(' + identifier + ')\\s*(?:\\[(?:' + identifier + ')?\\]|\\((?:(?:\\s*,\\s*)?[a-z]+)+\\s*\\))?',
+      fnOpener: identifier + '\\s+' + identifier + '\\s*\\(',
+      bool: 'bool',
+      function: 'function'
+    };
+  }
 
-CppParser.prototype.setup_settings = function () {
-  const nameToken = '[a-zA-Z_][a-zA-Z0-9_]*';
-  const identifier = util.format('(%s)(::%s)?(<%s>)?', nameToken, nameToken, nameToken);
-  this.settings = {
-    commentType: 'block',
-    typeInfo: false,
-    curlyTypes: false,
-    typeTag: 'param',
-    commentCloser: ' */',
-    fnIdentifier: identifier,
-    varIdentifier: '(' + identifier + ')\\s*(?:\\[(?:' + identifier + ')?\\]|\\((?:(?:\\s*,\\s*)?[a-z]+)+\\s*\\))?',
-    fnOpener: identifier + '\\s+' + identifier + '\\s*\\(',
-    bool: 'bool',
-    function: 'function'
-  };
-};
+  parse_function (line) {
+    const regex = xregexp(
+      '((?P<retval>' + this.settings.varIdentifier + ')[&*\\s]+)?' +
+          '(?P<name>' + this.settings.varIdentifier + ');?' +
+          // void fnName
+          // (arg1, arg2)
+          '\\s*\\(\\s*(?P<args>.*?)\\)'
+    );
+    const matches = xregexp.exec(line, regex);
 
-CppParser.prototype.parse_function = function (line) {
-  const regex = xregexp(
-    '((?P<retval>' + this.settings.varIdentifier + ')[&*\\s]+)?' +
-        '(?P<name>' + this.settings.varIdentifier + ');?' +
-        // void fnName
-        // (arg1, arg2)
-        '\\s*\\(\\s*(?P<args>.*?)\\)'
-  );
-  const matches = xregexp.exec(line, regex);
+    if (matches === null) {
+      return null;
+    }
 
-  if (matches === null) {
+    const args = matches.args || null;
+    const retval = matches.retval || null;
+
+    return [matches.name, args, retval];
+  }
+
+  parse_args (args) {
+    if (args.trim() === 'void') { return []; }
+    return super.parse_args(args);
+  }
+
+  get_arg_type (arg) {
+    if (arg === '...') {
+      // variable arguments
+      return 'VARARGS';
+    }
+    const regex = new RegExp('(' + this.settings.varIdentifier + '[&*\\s]+)');
+    const arrayRegex = new RegExp('[^[]+\\s*(\\[\\])?');
+    const matches = regex.exec(arg) || [];
+    const arrayMatches = arrayRegex.exec(arg) || [];
+    const result = (matches[1] || '[type]').replace(/\s+/g, '');
+    const arrayResult = (arrayMatches[1] || '').replace(/\s+/g, '');
+    return result + arrayResult;
+  }
+
+  get_arg_name (arg) {
+    if (arg === '...') {
+      // variable arguments
+      return 'VARARGS';
+    }
+    const regex = new RegExp(this.settings.varIdentifier + '(?:\\s*=.*)?$');
+    const matches = regex.exec(arg) || [];
+    return matches[1] || '[name]';
+  }
+
+  parse_var (line) {
     return null;
   }
 
-  const args = matches.args || null;
-  const retval = matches.retval || null;
-
-  return [matches.name, args, retval];
-};
-
-CppParser.prototype.parse_args = function (args) {
-  if (args.trim() === 'void') { return []; }
-  return DocsParser.prototype.parse_args.call(this, args);
-  // return super(JsdocsCPP, self).parseArgs(args)
-};
-
-CppParser.prototype.get_arg_type = function (arg) {
-  if (arg === '...') {
-    // variable arguments
-    return 'VARARGS';
+  guess_type_from_value (val) {
+    return null;
   }
-  const regex = new RegExp('(' + this.settings.varIdentifier + '[&*\\s]+)');
-  const arrayRegex = new RegExp('[^[]+\\s*(\\[\\])?');
-  const matches = regex.exec(arg) || [];
-  const arrayMatches = arrayRegex.exec(arg) || [];
-  const result = (matches[1] || '[type]').replace(/\s+/g, '');
-  const arrayResult = (arrayMatches[1] || '').replace(/\s+/g, '');
-  return result + arrayResult;
-};
 
-CppParser.prototype.get_arg_name = function (arg) {
-  if (arg === '...') {
-    // variable arguments
-    return 'VARARGS';
+  get_function_return_type (name, retval) {
+    return ((retval !== 'void') ? retval : null);
   }
-  const regex = new RegExp(this.settings.varIdentifier + '(?:\\s*=.*)?$');
-  const matches = regex.exec(arg) || [];
-  return matches[1] || '[name]';
 };
-
-CppParser.prototype.parse_var = function (line) {
-  return null;
-};
-
-CppParser.prototype.guess_type_from_value = function (val) {
-  return null;
-};
-
-CppParser.prototype.get_function_return_type = function (name, retval) {
-  return ((retval !== 'void') ? retval : null);
-};
-
-module.exports = CppParser;

--- a/lib/languages/cpp.js
+++ b/lib/languages/cpp.js
@@ -2,13 +2,7 @@ const DocsParser = require('../docsparser');
 const xregexp = require('xregexp');
 const util = require('util');
 
-function CppParser (settings) {
-  // this.setup_settings();
-  // call parent constructor
-  DocsParser.call(this, settings);
-}
-
-CppParser.prototype = Object.create(DocsParser.prototype);
+class CppParser extends DocsParser {}
 
 CppParser.prototype.setup_settings = function () {
   const nameToken = '[a-zA-Z_][a-zA-Z0-9_]*';

--- a/lib/languages/java.js
+++ b/lib/languages/java.js
@@ -2,11 +2,7 @@ const DocsParser = require('../docsparser');
 const xregexp = require('xregexp');
 const escape = require('../utils').escape;
 
-function JavaParser (settings) {
-  DocsParser.call(this, settings);
-}
-
-JavaParser.prototype = Object.create(DocsParser.prototype);
+class JavaParser extends DocsParser {}
 
 JavaParser.prototype.setup_settings = function () {
   const identifier = '[a-zA-Z_$][a-zA-Z_$0-9]*';

--- a/lib/languages/java.js
+++ b/lib/languages/java.js
@@ -82,9 +82,7 @@ module.exports = class JavaParser extends DocsParser {
     const out = super.formatFunction(name, args, retval, options);
 
     if (throwsArgs) {
-      throwsArgs.forEach(function (type) {
-        out.push(`@throws ${escape(type)} \${1:[description]}`);
-      });
+      throwsArgs.forEach(type => out.push(`@throws ${escape(type)} \${1:[description]}`));
     }
 
     return out;

--- a/lib/languages/java.js
+++ b/lib/languages/java.js
@@ -3,7 +3,7 @@ const xregexp = require('xregexp');
 const escape = require('../utils').escape;
 
 module.exports = class JavaParser extends DocsParser {
-  setup_settings () {
+  setupSettings () {
     const identifier = '[a-zA-Z_$][a-zA-Z_$0-9]*';
     this.settings = {
       commentType: 'block',
@@ -19,7 +19,7 @@ module.exports = class JavaParser extends DocsParser {
     };
   }
 
-  parse_function (line) {
+  parseFunction (line) {
     line = line.trim();
     const regex = xregexp(
       // Modifiers
@@ -57,7 +57,7 @@ module.exports = class JavaParser extends DocsParser {
     return [name, args, retval, argThrows];
   }
 
-  get_arg_name (arg) {
+  getArgName (arg) {
     if (typeof arg === 'string') {
       arg = arg.trim();
       const splited = arg.split(/\s/);
@@ -66,20 +66,20 @@ module.exports = class JavaParser extends DocsParser {
     return arg;
   }
 
-  parse_var (line) {
+  parseVar (line) {
     return null;
   }
 
-  guess_type_from_value (val) {
+  guessTypeFromValue (val) {
     return null;
   }
 
-  format_function (name, args, retval, throwsArgs, options) {
+  formatFunction (name, args, retval, throwsArgs, options) {
     if (typeof options === 'undefined') {
       options = {};
     }
 
-    const out = super.format_function(name, args, retval, options);
+    const out = super.formatFunction(name, args, retval, options);
 
     if (throwsArgs) {
       throwsArgs.forEach(function (type) {
@@ -90,11 +90,11 @@ module.exports = class JavaParser extends DocsParser {
     return out;
   }
 
-  get_function_return_type (name, retval) {
+  getFunctionReturnType (name, retval) {
     if (retval === 'void') { return null; } else { return retval; }
   }
 
-  get_definition (editor, pos, readLine) {
+  getDefinition (editor, pos, readLine) {
     const maxLines = 25; // don't go further than this
 
     let definition = '';

--- a/lib/languages/java.js
+++ b/lib/languages/java.js
@@ -2,147 +2,145 @@ const DocsParser = require('../docsparser');
 const xregexp = require('xregexp');
 const escape = require('../utils').escape;
 
-class JavaParser extends DocsParser {}
-
-JavaParser.prototype.setup_settings = function () {
-  const identifier = '[a-zA-Z_$][a-zA-Z_$0-9]*';
-  this.settings = {
-    commentType: 'block',
-    curlyTypes: false,
-    typeInfo: false,
-    typeTag: 'type',
-    varIdentifier: identifier,
-    fnIdentifier: identifier,
-    fnOpener: identifier + '(?:\\s+' + identifier + ')?\\s*\\(',
-    commentCloser: ' */',
-    bool: 'Boolean',
-    function: 'Function'
-  };
-};
-
-JavaParser.prototype.parse_function = function (line) {
-  line = line.trim();
-  const regex = xregexp(
-    // Modifiers
-    '(?:(public|protected|private|static|abstract|final|transient|synchronized|native|strictfp)\\s+)*' +
-        // Return value
-        '(?:(?P<retval>[a-zA-Z_$][\\<\\>\\., a-zA-Z_$0-9\\[\\]]+)\\s+)?' +
-        // Method name
-        '(?P<name>' + this.settings.fnIdentifier + ')\\s*' +
-        // Params
-        '\\((?P<args>.*?)\\)\\s*' +
-        // # Throws ,
-        '(?:throws\\s*(?P<throwed>[a-zA-Z_$0-9\\.,\\s]*))?'
-  );
-
-  const matches = xregexp.exec(line, regex);
-  if (matches === null) { return null; }
-
-  const name = matches.name || '';
-  const retval = matches.retval || null;
-
-  let argThrows;
-  if (matches.throwed) {
-    argThrows = matches.throwed.trim().split(/\s*,\s*/);
-  } else {
-    argThrows = null;
+module.exports = class JavaParser extends DocsParser {
+  setup_settings () {
+    const identifier = '[a-zA-Z_$][a-zA-Z_$0-9]*';
+    this.settings = {
+      commentType: 'block',
+      curlyTypes: false,
+      typeInfo: false,
+      typeTag: 'type',
+      varIdentifier: identifier,
+      fnIdentifier: identifier,
+      fnOpener: identifier + '(?:\\s+' + identifier + ')?\\s*\\(',
+      commentCloser: ' */',
+      bool: 'Boolean',
+      function: 'Function'
+    };
   }
 
-  let args;
-  if (matches.args) {
-    args = matches.args.trim();
-  } else {
-    args = null;
+  parse_function (line) {
+    line = line.trim();
+    const regex = xregexp(
+      // Modifiers
+      '(?:(public|protected|private|static|abstract|final|transient|synchronized|native|strictfp)\\s+)*' +
+          // Return value
+          '(?:(?P<retval>[a-zA-Z_$][\\<\\>\\., a-zA-Z_$0-9\\[\\]]+)\\s+)?' +
+          // Method name
+          '(?P<name>' + this.settings.fnIdentifier + ')\\s*' +
+          // Params
+          '\\((?P<args>.*?)\\)\\s*' +
+          // # Throws ,
+          '(?:throws\\s*(?P<throwed>[a-zA-Z_$0-9\\.,\\s]*))?'
+    );
+
+    const matches = xregexp.exec(line, regex);
+    if (matches === null) { return null; }
+
+    const name = matches.name || '';
+    const retval = matches.retval || null;
+
+    let argThrows;
+    if (matches.throwed) {
+      argThrows = matches.throwed.trim().split(/\s*,\s*/);
+    } else {
+      argThrows = null;
+    }
+
+    let args;
+    if (matches.args) {
+      args = matches.args.trim();
+    } else {
+      args = null;
+    }
+
+    return [name, args, retval, argThrows];
   }
 
-  return [name, args, retval, argThrows];
-};
-
-JavaParser.prototype.get_arg_name = function (arg) {
-  if (typeof arg === 'string') {
-    arg = arg.trim();
-    const splited = arg.split(/\s/);
-    return splited[splited.length - 1];
-  }
-  return arg;
-};
-
-JavaParser.prototype.parse_var = function (line) {
-  return null;
-};
-
-JavaParser.prototype.guess_type_from_value = function (val) {
-  return null;
-};
-
-JavaParser.prototype.format_function = function (name, args, retval, throwsArgs, options) {
-  if (typeof options === 'undefined') {
-    options = {};
+  get_arg_name (arg) {
+    if (typeof arg === 'string') {
+      arg = arg.trim();
+      const splited = arg.split(/\s/);
+      return splited[splited.length - 1];
+    }
+    return arg;
   }
 
-  const out = DocsParser.prototype.format_function.call(this, name, args, retval, options);
-
-  if (throwsArgs) {
-    throwsArgs.forEach(function (type) {
-      out.push(`@throws ${escape(type)} \${1:[description]}`);
-    });
+  parse_var (line) {
+    return null;
   }
 
-  return out;
-};
+  guess_type_from_value (val) {
+    return null;
+  }
 
-JavaParser.prototype.get_function_return_type = function (name, retval) {
-  if (retval === 'void') { return null; } else { return retval; }
-};
+  format_function (name, args, retval, throwsArgs, options) {
+    if (typeof options === 'undefined') {
+      options = {};
+    }
 
-JavaParser.prototype.get_definition = function (editor, pos, readLine) {
-  const maxLines = 25; // don't go further than this
+    const out = super.format_function(name, args, retval, options);
 
-  let definition = '';
-  let openCurlyAnnotation = false;
-  let openParenAnnotation = false;
+    if (throwsArgs) {
+      throwsArgs.forEach(function (type) {
+        out.push(`@throws ${escape(type)} \${1:[description]}`);
+      });
+    }
 
-  for (let i = 0; i < maxLines; i++) {
-    let line = readLine(editor, pos);
-    if (line == null) { break; }
+    return out;
+  }
 
-    pos.row += 1;
-    // Move past empty lines
-    if (line.search(/^\s*$/) > -1) { continue; }
+  get_function_return_type (name, retval) {
+    if (retval === 'void') { return null; } else { return retval; }
+  }
 
-    // strip comments
-    line = line.replace(/\/\/.*/, '');
-    line = line.replace(/\/\*.*\*\//, '');
-    if (definition === '') {
-      // Must check here for function opener on same line as annotation
-      if (this.settings.fnOpener && (line.search(RegExp(this.settings.fnOpener)) > -1)) {
+  get_definition (editor, pos, readLine) {
+    const maxLines = 25; // don't go further than this
 
-      } else if (line.search(/^\s*@/) > -1) {
-        // Handle Annotations
-        if ((line.search('{') > -1) && line.search('}') === -1) { openCurlyAnnotation = true; }
-        if ((line.search('\\(') > -1) && line.search('\\)') === -1) { openParenAnnotation = true; }
-        continue;
-      } else if (openCurlyAnnotation) {
-        if (line.search('}') > -1) { openCurlyAnnotation = false; }
-        continue;
-      } else if (openParenAnnotation) {
-        if (line.search('\\)') > -1) { openParenAnnotation = false; }
-      } else if (line.search(/^\s*$/) > -1) {
-        continue;
-      } else if (!(this.settings.fnOpener) || line.search(RegExp(this.settings.fnOpener)) === -1) {
-        // Check for function
-        definition = line;
+    let definition = '';
+    let openCurlyAnnotation = false;
+    let openParenAnnotation = false;
+
+    for (let i = 0; i < maxLines; i++) {
+      let line = readLine(editor, pos);
+      if (line == null) { break; }
+
+      pos.row += 1;
+      // Move past empty lines
+      if (line.search(/^\s*$/) > -1) { continue; }
+
+      // strip comments
+      line = line.replace(/\/\/.*/, '');
+      line = line.replace(/\/\*.*\*\//, '');
+      if (definition === '') {
+        // Must check here for function opener on same line as annotation
+        if (this.settings.fnOpener && (line.search(RegExp(this.settings.fnOpener)) > -1)) {
+
+        } else if (line.search(/^\s*@/) > -1) {
+          // Handle Annotations
+          if ((line.search('{') > -1) && line.search('}') === -1) { openCurlyAnnotation = true; }
+          if ((line.search('\\(') > -1) && line.search('\\)') === -1) { openParenAnnotation = true; }
+          continue;
+        } else if (openCurlyAnnotation) {
+          if (line.search('}') > -1) { openCurlyAnnotation = false; }
+          continue;
+        } else if (openParenAnnotation) {
+          if (line.search('\\)') > -1) { openParenAnnotation = false; }
+        } else if (line.search(/^\s*$/) > -1) {
+          continue;
+        } else if (!(this.settings.fnOpener) || line.search(RegExp(this.settings.fnOpener)) === -1) {
+          // Check for function
+          definition = line;
+          break;
+        }
+      }
+      definition += line;
+      if ((line.indexOf(';') > -1) || (line.indexOf('{') > -1)) {
+        const regex = new RegExp('\\s*[;{]\\s*$', 'g');
+        definition = definition.replace(regex, '');
         break;
       }
     }
-    definition += line;
-    if ((line.indexOf(';') > -1) || (line.indexOf('{') > -1)) {
-      const regex = new RegExp('\\s*[;{]\\s*$', 'g');
-      definition = definition.replace(regex, '');
-      break;
-    }
+    return definition;
   }
-  return definition;
 };
-
-module.exports = JavaParser;

--- a/lib/languages/javascript.js
+++ b/lib/languages/javascript.js
@@ -2,13 +2,7 @@ const util = require('util');
 const DocsParser = require('../docsparser');
 const xregexp = require('xregexp');
 
-function JsParser (settings) {
-  // this.setup_settings();
-  // call parent constructor
-  DocsParser.call(this, settings);
-}
-
-JsParser.prototype = Object.create(DocsParser.prototype);
+class JsParser extends DocsParser {}
 
 JsParser.prototype.setup_settings = function () {
   const identifier = '[a-zA-Z_$][a-zA-Z_$0-9]*';

--- a/lib/languages/javascript.js
+++ b/lib/languages/javascript.js
@@ -197,9 +197,7 @@ module.exports = class JsParser extends DocsParser {
     const lowerPrimitives = this.editorSettings.lower_case_primitives || false;
     const shortPrimitives = this.editorSettings.short_primitives || false;
     let varType;
-    const capitalize = function (str) {
-      return str.charAt(0).toUpperCase() + str.slice(1);
-    };
+    const capitalize = str => str.charAt(0).toUpperCase() + str.slice(1);
     if (this.isNumeric(val)) {
       varType = 'number';
       return (lowerPrimitives ? varType : capitalize(varType));

--- a/lib/languages/javascript.js
+++ b/lib/languages/javascript.js
@@ -3,7 +3,7 @@ const DocsParser = require('../docsparser');
 const xregexp = require('xregexp');
 
 module.exports = class JsParser extends DocsParser {
-  setup_settings () {
+  setupSettings () {
     const identifier = '[a-zA-Z_$][a-zA-Z_$0-9]*';
     this.settings = {
       commentType: 'block',
@@ -22,7 +22,7 @@ module.exports = class JsParser extends DocsParser {
     };
   }
 
-  parse_class (line) {
+  parseClass (line) {
     const regex = xregexp(
       '^\\s*class\\s+' +
           '(?P<name>' + this.settings.classIdentifier + ')' +
@@ -35,7 +35,7 @@ module.exports = class JsParser extends DocsParser {
     return [matches.name, matches.extends || null];
   }
 
-  format_class (name, superClass) {
+  formatClass (name, superClass) {
     const out = [];
     out.push(`\${1:[${escape(name)} description]}`);
 
@@ -46,7 +46,7 @@ module.exports = class JsParser extends DocsParser {
     return out;
   }
 
-  parse_function (line) {
+  parseFunction (line) {
     // single quotes indicate what will be matched in each line
     const preFunction = '^' +
           // '  'var foo = function bar (baz, quaz) {}
@@ -143,13 +143,13 @@ module.exports = class JsParser extends DocsParser {
 
     const options = {};
     if (functionRegexMatch && name.length > 0 && name[0] === name[0].toUpperCase()) {
-      options.is_constructor = true;
+      options.isConstructor = true;
     }
 
     return [name, args, retval, options];
   }
 
-  parse_var (line) {
+  parseVar (line) {
     //   var foo = blah,
     //       foo = blah;
     //   baz.foo = blah;
@@ -165,7 +165,7 @@ module.exports = class JsParser extends DocsParser {
     return [matches.name, matches.val.trim()];
   }
 
-  parse_arg (arg) {
+  parseArg (arg) {
     const regex = xregexp(
       '(?P<name>' + this.settings.varIdentifier + ')(\\s*=\\s*(?P<value>.*))?'
     );
@@ -173,18 +173,18 @@ module.exports = class JsParser extends DocsParser {
     return xregexp.exec(arg, regex);
   }
 
-  get_arg_type (arg) {
-    const matches = this.parse_arg(arg);
+  getArgType (arg) {
+    const matches = this.parseArg(arg);
 
     if (matches && matches.value) {
-      return this.guess_type_from_value(matches.value);
+      return this.guessTypeFromValue(matches.value);
     }
 
     return null;
   }
 
-  get_arg_name (arg) {
-    const matches = this.parse_arg(arg);
+  getArgName (arg) {
+    const matches = this.parseArg(arg);
 
     if (matches && matches.value) {
       return util.format('[%s=%s]', matches.name, matches.value);
@@ -193,14 +193,14 @@ module.exports = class JsParser extends DocsParser {
     return matches ? matches.name : arg;
   }
 
-  guess_type_from_value (val) {
-    const lowerPrimitives = this.editor_settings.lower_case_primitives || false;
-    const shortPrimitives = this.editor_settings.short_primitives || false;
+  guessTypeFromValue (val) {
+    const lowerPrimitives = this.editorSettings.lower_case_primitives || false;
+    const shortPrimitives = this.editorSettings.short_primitives || false;
     let varType;
     const capitalize = function (str) {
       return str.charAt(0).toUpperCase() + str.slice(1);
     };
-    if (this.is_numeric(val)) {
+    if (this.isNumeric(val)) {
       varType = 'number';
       return (lowerPrimitives ? varType : capitalize(varType));
     }
@@ -230,7 +230,7 @@ module.exports = class JsParser extends DocsParser {
     return null;
   }
 
-  get_function_return_type (name, retval) {
+  getFunctionReturnType (name, retval) {
     if (name === 'constructor') {
       return null;
     }
@@ -238,10 +238,10 @@ module.exports = class JsParser extends DocsParser {
     if (retval) {
       return retval;
     }
-    return super.get_function_return_type(name, retval);
+    return super.getFunctionReturnType(name, retval);
   }
 
-  is_existing_comment (line) {
+  isExistingComment (line) {
     // handle ES2015 generator shorhand for Object
     // example: * funcName(arg1, arg2, ...restArg) {}
     if (/^\s*\*\s*[$_A-Za-z][$\w]+\s*\(.*?\)\s*\{/.test(line)) {

--- a/lib/languages/javascript.js
+++ b/lib/languages/javascript.js
@@ -2,253 +2,251 @@ const util = require('util');
 const DocsParser = require('../docsparser');
 const xregexp = require('xregexp');
 
-class JsParser extends DocsParser {}
-
-JsParser.prototype.setup_settings = function () {
-  const identifier = '[a-zA-Z_$][a-zA-Z_$0-9]*';
-  this.settings = {
-    commentType: 'block',
-    // curly brackets around the type information
-    curlyTypes: true,
-    typeInfo: true,
-    typeTag: 'type',
-    // technically, they can contain all sorts of unicode, but w/e
-    varIdentifier: identifier,
-    fnIdentifier: identifier,
-    classIdentifier: identifier,
-    fnOpener: 'function(?:\\s+' + identifier + ')?\\s*\\(',
-    commentCloser: ' */',
-    bool: 'Boolean',
-    function: 'Function'
-  };
-};
-
-JsParser.prototype.parse_class = function (line) {
-  const regex = xregexp(
-    '^\\s*class\\s+' +
-        '(?P<name>' + this.settings.classIdentifier + ')' +
-        '(:?\\s+extends\\s+(?P<extends>' + this.settings.classIdentifier + '))?'
-  );
-
-  const matches = xregexp.exec(line, regex);
-  if (!matches) { return null; }
-
-  return [matches.name, matches.extends || null];
-};
-
-JsParser.prototype.format_class = function (name, superClass) {
-  const out = [];
-  out.push(`\${1:[${escape(name)} description]}`);
-
-  if (superClass) {
-    out.push('@extends ' + superClass);
+module.exports = class JsParser extends DocsParser {
+  setup_settings () {
+    const identifier = '[a-zA-Z_$][a-zA-Z_$0-9]*';
+    this.settings = {
+      commentType: 'block',
+      // curly brackets around the type information
+      curlyTypes: true,
+      typeInfo: true,
+      typeTag: 'type',
+      // technically, they can contain all sorts of unicode, but w/e
+      varIdentifier: identifier,
+      fnIdentifier: identifier,
+      classIdentifier: identifier,
+      fnOpener: 'function(?:\\s+' + identifier + ')?\\s*\\(',
+      commentCloser: ' */',
+      bool: 'Boolean',
+      function: 'Function'
+    };
   }
 
-  return out;
-};
+  parse_class (line) {
+    const regex = xregexp(
+      '^\\s*class\\s+' +
+          '(?P<name>' + this.settings.classIdentifier + ')' +
+          '(:?\\s+extends\\s+(?P<extends>' + this.settings.classIdentifier + '))?'
+    );
 
-JsParser.prototype.parse_function = function (line) {
-  // single quotes indicate what will be matched in each line
-  const preFunction = '^' +
-        // '  'var foo = function bar (baz, quaz) {}
-        '\\s*' +
-        '(?:' +
-            // 'return' foo = function bar (baz, quaz) {}
-            'return\\s+' +
-            '|' +
-            // 'export default 'var foo = function bar (baz, quaz) {}
-            '(?:export\\s+(?:default\\s+)?)?' +
-            //  export default 'var 'foo = function bar (baz, quaz) {}
-            '(?:(?:var|let|const)\\s+)?' +
-        ')?' +
-        '(?:' +
-            //   var 'bar.prototype.'foo = function bar (baz, quaz) {}
-            '(?:[a-zA-Z_$][a-zA-Z_$0-9.]*\\.)?' +
-            //   var 'foo = 'function bar (baz, quaz) {}
-            '(?P<name1>' + this.settings.varIdentifier + ')\\s*[:=]\\s*' +
-        ')?';
+    const matches = xregexp.exec(line, regex);
+    if (!matches) { return null; }
 
-  const modifiers = '(?:\\bstatic\\s+)?(?P<promise>\\basync\\s+)?';
-
-  const functionRegex = xregexp(
-    preFunction +
-        modifiers +
-        //   var foo = 'function 'bar (baz, quaz) {}
-        '(?:function(?P<generator>\\s*\\*)?)\\s*' +
-        //   var foo = function 'bar '(baz, quaz) {}
-        '(?:\\b(?P<name2>' + this.settings.fnIdentifier + '))?\\s*' +
-        //   var foo = function bar '(baz, quaz)' {}
-        '\\(\\s*(?P<args>.*?)\\)'
-  );
-
-  const methodRegex = xregexp(
-    '^' +
-        '\\s*' +
-        modifiers +
-        '(?P<generator>\\*)?\\s*' +
-        '(?P<name2>' + this.settings.fnIdentifier + ')\\s*' +
-        '\\(\\s*(?P<args>.*?)\\)\\s*' +
-        '{'
-  );
-
-  const geterSetterMethodRegex = xregexp(
-    '^' +
-        '\\s*' +
-        '(?:get|set)\\s+' +
-        '(?P<name2>' + this.settings.fnIdentifier + ')\\s*' +
-        '\\(\\s*(?P<args>.*?)\\)\\s*' +
-        '{'
-  );
-
-  const arrowFunctionRegex = xregexp(
-    preFunction +
-        '(?P<promise>async\\s+)?' +
-        '(?:' +
-            //   var foo = 'bar' => {}
-            '(?P<arg>' + this.settings.varIdentifier + ')' +
-            '|' +
-            //   var foo = '(bar, baz)' => {}
-            '\\(\\s*(?P<args>.*?)\\)' +
-        ')\\s*' +
-        //   var foo = bar '=>' {}
-        '=>\\s*'
-  );
-
-  let functionRegexMatch = null;
-  // const methodRegexMatch = null;
-  // const geterSetterMethodRegexMatch = null;
-  // const arrowFunctionRegexMatch = null;
-
-  // XXX: Note assignments
-  const matches = (
-    (functionRegexMatch = xregexp.exec(line, functionRegex)) ||
-            (/* methodRegexMatch = */xregexp.exec(line, methodRegex)) ||
-            (/* geterSetterMethodRegexMatch = */xregexp.exec(line, geterSetterMethodRegex)) ||
-            (/* arrowFunctionRegexMatch = */xregexp.exec(line, arrowFunctionRegex))
-  );
-
-  if (matches === null) {
-    return null;
-  }
-  // grab the name out of "name1 = function name2(foo)" preferring name1
-  const name = matches.name1 || matches.name2 || '';
-  const args = matches.args || matches.arg || null;
-
-  // check for async method to set retval to promise
-  let retval = null;
-  if (matches.promise) {
-    retval = 'Promise';
-  } else if (matches.generator) {
-    retval = 'Generator';
+    return [matches.name, matches.extends || null];
   }
 
-  const options = {};
-  if (functionRegexMatch && name.length > 0 && name[0] === name[0].toUpperCase()) {
-    options.is_constructor = true;
+  format_class (name, superClass) {
+    const out = [];
+    out.push(`\${1:[${escape(name)} description]}`);
+
+    if (superClass) {
+      out.push('@extends ' + superClass);
+    }
+
+    return out;
   }
 
-  return [name, args, retval, options];
-};
+  parse_function (line) {
+    // single quotes indicate what will be matched in each line
+    const preFunction = '^' +
+          // '  'var foo = function bar (baz, quaz) {}
+          '\\s*' +
+          '(?:' +
+              // 'return' foo = function bar (baz, quaz) {}
+              'return\\s+' +
+              '|' +
+              // 'export default 'var foo = function bar (baz, quaz) {}
+              '(?:export\\s+(?:default\\s+)?)?' +
+              //  export default 'var 'foo = function bar (baz, quaz) {}
+              '(?:(?:var|let|const)\\s+)?' +
+          ')?' +
+          '(?:' +
+              //   var 'bar.prototype.'foo = function bar (baz, quaz) {}
+              '(?:[a-zA-Z_$][a-zA-Z_$0-9.]*\\.)?' +
+              //   var 'foo = 'function bar (baz, quaz) {}
+              '(?P<name1>' + this.settings.varIdentifier + ')\\s*[:=]\\s*' +
+          ')?';
 
-JsParser.prototype.parse_var = function (line) {
-  //   var foo = blah,
-  //       foo = blah;
-  //   baz.foo = blah;
-  //   baz = {
-  //        foo : blah
-  //   }
-  const regex = xregexp('(?P<name>' + this.settings.varIdentifier + ')\\s*[=:]\\s*(?P<val>.*?)(?:[;,]|$)');
-  const matches = xregexp.exec(line, regex);
-  if (matches === null) {
-    return null;
+    const modifiers = '(?:\\bstatic\\s+)?(?P<promise>\\basync\\s+)?';
+
+    const functionRegex = xregexp(
+      preFunction +
+          modifiers +
+          //   var foo = 'function 'bar (baz, quaz) {}
+          '(?:function(?P<generator>\\s*\\*)?)\\s*' +
+          //   var foo = function 'bar '(baz, quaz) {}
+          '(?:\\b(?P<name2>' + this.settings.fnIdentifier + '))?\\s*' +
+          //   var foo = function bar '(baz, quaz)' {}
+          '\\(\\s*(?P<args>.*?)\\)'
+    );
+
+    const methodRegex = xregexp(
+      '^' +
+          '\\s*' +
+          modifiers +
+          '(?P<generator>\\*)?\\s*' +
+          '(?P<name2>' + this.settings.fnIdentifier + ')\\s*' +
+          '\\(\\s*(?P<args>.*?)\\)\\s*' +
+          '{'
+    );
+
+    const geterSetterMethodRegex = xregexp(
+      '^' +
+          '\\s*' +
+          '(?:get|set)\\s+' +
+          '(?P<name2>' + this.settings.fnIdentifier + ')\\s*' +
+          '\\(\\s*(?P<args>.*?)\\)\\s*' +
+          '{'
+    );
+
+    const arrowFunctionRegex = xregexp(
+      preFunction +
+          '(?P<promise>async\\s+)?' +
+          '(?:' +
+              //   var foo = 'bar' => {}
+              '(?P<arg>' + this.settings.varIdentifier + ')' +
+              '|' +
+              //   var foo = '(bar, baz)' => {}
+              '\\(\\s*(?P<args>.*?)\\)' +
+          ')\\s*' +
+          //   var foo = bar '=>' {}
+          '=>\\s*'
+    );
+
+    let functionRegexMatch = null;
+    // const methodRegexMatch = null;
+    // const geterSetterMethodRegexMatch = null;
+    // const arrowFunctionRegexMatch = null;
+
+    // XXX: Note assignments
+    const matches = (
+      (functionRegexMatch = xregexp.exec(line, functionRegex)) ||
+              (/* methodRegexMatch = */xregexp.exec(line, methodRegex)) ||
+              (/* geterSetterMethodRegexMatch = */xregexp.exec(line, geterSetterMethodRegex)) ||
+              (/* arrowFunctionRegexMatch = */xregexp.exec(line, arrowFunctionRegex))
+    );
+
+    if (matches === null) {
+      return null;
+    }
+    // grab the name out of "name1 = function name2(foo)" preferring name1
+    const name = matches.name1 || matches.name2 || '';
+    const args = matches.args || matches.arg || null;
+
+    // check for async method to set retval to promise
+    let retval = null;
+    if (matches.promise) {
+      retval = 'Promise';
+    } else if (matches.generator) {
+      retval = 'Generator';
+    }
+
+    const options = {};
+    if (functionRegexMatch && name.length > 0 && name[0] === name[0].toUpperCase()) {
+      options.is_constructor = true;
+    }
+
+    return [name, args, retval, options];
   }
-  // variable name, variable value
-  return [matches.name, matches.val.trim()];
-};
 
-JsParser.prototype.parse_arg = function (arg) {
-  const regex = xregexp(
-    '(?P<name>' + this.settings.varIdentifier + ')(\\s*=\\s*(?P<value>.*))?'
-  );
-
-  return xregexp.exec(arg, regex);
-};
-
-JsParser.prototype.get_arg_type = function (arg) {
-  const matches = this.parse_arg(arg);
-
-  if (matches && matches.value) {
-    return this.guess_type_from_value(matches.value);
+  parse_var (line) {
+    //   var foo = blah,
+    //       foo = blah;
+    //   baz.foo = blah;
+    //   baz = {
+    //        foo : blah
+    //   }
+    const regex = xregexp('(?P<name>' + this.settings.varIdentifier + ')\\s*[=:]\\s*(?P<val>.*?)(?:[;,]|$)');
+    const matches = xregexp.exec(line, regex);
+    if (matches === null) {
+      return null;
+    }
+    // variable name, variable value
+    return [matches.name, matches.val.trim()];
   }
 
-  return null;
-};
+  parse_arg (arg) {
+    const regex = xregexp(
+      '(?P<name>' + this.settings.varIdentifier + ')(\\s*=\\s*(?P<value>.*))?'
+    );
 
-JsParser.prototype.get_arg_name = function (arg) {
-  const matches = this.parse_arg(arg);
-
-  if (matches && matches.value) {
-    return util.format('[%s=%s]', matches.name, matches.value);
+    return xregexp.exec(arg, regex);
   }
 
-  return matches ? matches.name : arg;
-};
+  get_arg_type (arg) {
+    const matches = this.parse_arg(arg);
 
-JsParser.prototype.guess_type_from_value = function (val) {
-  const lowerPrimitives = this.editor_settings.lower_case_primitives || false;
-  const shortPrimitives = this.editor_settings.short_primitives || false;
-  let varType;
-  const capitalize = function (str) {
-    return str.charAt(0).toUpperCase() + str.slice(1);
-  };
-  if (this.is_numeric(val)) {
-    varType = 'number';
-    return (lowerPrimitives ? varType : capitalize(varType));
-  }
-  if ((val[0] === '\'') || (val[0] === '"')) {
-    varType = 'string';
-    return (lowerPrimitives ? varType : capitalize(varType));
-  }
-  if (val[0] === '[') {
-    return 'Array';
-  }
-  if (val[0] === '{') {
-    return 'Object';
-  }
-  if ((val === 'true') || (val === 'false')) {
-    const retVal = (shortPrimitives ? 'bool' : 'boolean');
-    return (lowerPrimitives ? retVal : capitalize(retVal));
-  }
-  let regex = new RegExp('^RegExp|^\\/[^/*].*\\/$');
-  if (regex.test(val)) {
-    return 'RegExp';
-  }
-  if (val.slice(0, 4) === 'new ') {
-    regex = new RegExp('new (' + this.settings.fnIdentifier + ')');
-    const matches = regex.exec(val);
-    return (matches[0] && matches[1]) || null;
-  }
-  return null;
-};
+    if (matches && matches.value) {
+      return this.guess_type_from_value(matches.value);
+    }
 
-JsParser.prototype.get_function_return_type = function (name, retval) {
-  if (name === 'constructor') {
     return null;
   }
 
-  if (retval) {
-    return retval;
-  }
-  return DocsParser.prototype.get_function_return_type.call(this, name, retval);
-};
+  get_arg_name (arg) {
+    const matches = this.parse_arg(arg);
 
-JsParser.prototype.is_existing_comment = function (line) {
-  // handle ES2015 generator shorhand for Object
-  // example: * funcName(arg1, arg2, ...restArg) {}
-  if (/^\s*\*\s*[$_A-Za-z][$\w]+\s*\(.*?\)\s*\{/.test(line)) {
-    return false;
-  }
-  return /^\s*\*/.test(line);
-};
+    if (matches && matches.value) {
+      return util.format('[%s=%s]', matches.name, matches.value);
+    }
 
-module.exports = JsParser;
+    return matches ? matches.name : arg;
+  }
+
+  guess_type_from_value (val) {
+    const lowerPrimitives = this.editor_settings.lower_case_primitives || false;
+    const shortPrimitives = this.editor_settings.short_primitives || false;
+    let varType;
+    const capitalize = function (str) {
+      return str.charAt(0).toUpperCase() + str.slice(1);
+    };
+    if (this.is_numeric(val)) {
+      varType = 'number';
+      return (lowerPrimitives ? varType : capitalize(varType));
+    }
+    if ((val[0] === '\'') || (val[0] === '"')) {
+      varType = 'string';
+      return (lowerPrimitives ? varType : capitalize(varType));
+    }
+    if (val[0] === '[') {
+      return 'Array';
+    }
+    if (val[0] === '{') {
+      return 'Object';
+    }
+    if ((val === 'true') || (val === 'false')) {
+      const retVal = (shortPrimitives ? 'bool' : 'boolean');
+      return (lowerPrimitives ? retVal : capitalize(retVal));
+    }
+    let regex = new RegExp('^RegExp|^\\/[^/*].*\\/$');
+    if (regex.test(val)) {
+      return 'RegExp';
+    }
+    if (val.slice(0, 4) === 'new ') {
+      regex = new RegExp('new (' + this.settings.fnIdentifier + ')');
+      const matches = regex.exec(val);
+      return (matches[0] && matches[1]) || null;
+    }
+    return null;
+  }
+
+  get_function_return_type (name, retval) {
+    if (name === 'constructor') {
+      return null;
+    }
+
+    if (retval) {
+      return retval;
+    }
+    return super.get_function_return_type(name, retval);
+  }
+
+  is_existing_comment (line) {
+    // handle ES2015 generator shorhand for Object
+    // example: * funcName(arg1, arg2, ...restArg) {}
+    if (/^\s*\*\s*[$_A-Za-z][$\w]+\s*\(.*?\)\s*\{/.test(line)) {
+      return false;
+    }
+    return /^\s*\*/.test(line);
+  }
+};

--- a/lib/languages/objc.js
+++ b/lib/languages/objc.js
@@ -2,7 +2,7 @@ const DocsParser = require('../docsparser');
 const xregexp = require('xregexp');
 
 module.exports = class ObjCParser extends DocsParser {
-  setup_settings () {
+  setupSettings () {
     const identifier = '[a-zA-Z_$][a-zA-Z_$0-9]*';
     this.settings = {
       commentType: 'block',
@@ -20,7 +20,7 @@ module.exports = class ObjCParser extends DocsParser {
     };
   }
 
-  get_definition (editor, pos, readLine) {
+  getDefinition (editor, pos, readLine) {
     const maxLines = 25; // don't go further than this
 
     let definition = '';
@@ -48,7 +48,7 @@ module.exports = class ObjCParser extends DocsParser {
     return definition;
   }
 
-  parse_function (line) {
+  parseFunction (line) {
     // this is terrible, don't judge me
     const typeRegex = '[a-zA-Z_$][a-zA-Z0-9_$]*\\s*\\**';
     let regex = xregexp(
@@ -86,7 +86,7 @@ module.exports = class ObjCParser extends DocsParser {
     return [name, args.join('|||'), matches.retval];
   }
 
-  parse_args (args) {
+  parseArgs (args) {
     const out = [];
     const argList = args.split('|||');
     for (let i = 0; i < argList.length; i++) {
@@ -97,11 +97,11 @@ module.exports = class ObjCParser extends DocsParser {
     return out;
   }
 
-  get_function_return_type (name, retval) {
+  getFunctionReturnType (name, retval) {
     if ((retval !== 'void') && (retval !== 'IBAction')) { return retval; } else { return null; }
   }
 
-  parse_var (line) {
+  parseVar (line) {
     return null;
   }
 };

--- a/lib/languages/objc.js
+++ b/lib/languages/objc.js
@@ -1,11 +1,7 @@
 const DocsParser = require('../docsparser');
 const xregexp = require('xregexp');
 
-function ObjCParser (settings) {
-  DocsParser.call(this, settings);
-}
-
-ObjCParser.prototype = Object.create(DocsParser.prototype);
+class ObjCParser extends DocsParser {}
 
 ObjCParser.prototype.setup_settings = function () {
   const identifier = '[a-zA-Z_$][a-zA-Z_$0-9]*';

--- a/lib/languages/objc.js
+++ b/lib/languages/objc.js
@@ -1,109 +1,107 @@
 const DocsParser = require('../docsparser');
 const xregexp = require('xregexp');
 
-class ObjCParser extends DocsParser {}
+module.exports = class ObjCParser extends DocsParser {
+  setup_settings () {
+    const identifier = '[a-zA-Z_$][a-zA-Z_$0-9]*';
+    this.settings = {
+      commentType: 'block',
+      // curly brackets around the type information
+      curlyTypes: true,
+      typeInfo: true,
+      typeTag: 'type',
+      // technically, they can contain all sorts of unicode, but w/e
+      varIdentifier: identifier,
+      fnIdentifier: identifier,
+      fnOpener: '^\\s*[-+]',
+      commentCloser: ' */',
+      bool: 'Boolean',
+      function: 'Function'
+    };
+  }
 
-ObjCParser.prototype.setup_settings = function () {
-  const identifier = '[a-zA-Z_$][a-zA-Z_$0-9]*';
-  this.settings = {
-    commentType: 'block',
-    // curly brackets around the type information
-    curlyTypes: true,
-    typeInfo: true,
-    typeTag: 'type',
-    // technically, they can contain all sorts of unicode, but w/e
-    varIdentifier: identifier,
-    fnIdentifier: identifier,
-    fnOpener: '^\\s*[-+]',
-    commentCloser: ' */',
-    bool: 'Boolean',
-    function: 'Function'
-  };
-};
+  get_definition (editor, pos, readLine) {
+    const maxLines = 25; // don't go further than this
 
-ObjCParser.prototype.get_definition = function (editor, pos, readLine) {
-  const maxLines = 25; // don't go further than this
+    let definition = '';
+    for (let i = 0; i < maxLines; i++) {
+      let line = readLine(editor, pos);
+      if (line == null) { break; }
 
-  let definition = '';
-  for (let i = 0; i < maxLines; i++) {
-    let line = readLine(editor, pos);
-    if (line == null) { break; }
-
-    // goto next line
-    pos.row += 1;
-    // strip comments
-    line = line.replace(/\/\/.*/, '');
-    if (definition === '') {
-      if ((!this.settings.fnOpener) || !(line.search(RegExp(this.settings.fnOpener)) > -1)) {
-        definition = line;
+      // goto next line
+      pos.row += 1;
+      // strip comments
+      line = line.replace(/\/\/.*/, '');
+      if (definition === '') {
+        if ((!this.settings.fnOpener) || !(line.search(RegExp(this.settings.fnOpener)) > -1)) {
+          definition = line;
+          break;
+        }
+      }
+      definition += line;
+      if ((line.indexOf(';') > -1) || (line.indexOf('{') > -1)) {
+        const regex = new RegExp('\\s*[;{]\\s*$', 'g');
+        definition = definition.replace(regex, '');
         break;
       }
     }
-    definition += line;
-    if ((line.indexOf(';') > -1) || (line.indexOf('{') > -1)) {
-      const regex = new RegExp('\\s*[;{]\\s*$', 'g');
-      definition = definition.replace(regex, '');
-      break;
-    }
+    return definition;
   }
-  return definition;
-};
 
-ObjCParser.prototype.parse_function = function (line) {
-  // this is terrible, don't judge me
-  const typeRegex = '[a-zA-Z_$][a-zA-Z0-9_$]*\\s*\\**';
-  let regex = xregexp(
-    '[-+]\\s+\\(\\s*(?P<retval>' + typeRegex + ')\\s*\\)\\s*' +
-        '(?P<name>[a-zA-Z_$][a-zA-Z0-9_$]*)' +
-        // void fnName
-        // (arg1, arg2)
-        '\\s*(?::(?P<args>.*))?'
-  );
+  parse_function (line) {
+    // this is terrible, don't judge me
+    const typeRegex = '[a-zA-Z_$][a-zA-Z0-9_$]*\\s*\\**';
+    let regex = xregexp(
+      '[-+]\\s+\\(\\s*(?P<retval>' + typeRegex + ')\\s*\\)\\s*' +
+          '(?P<name>[a-zA-Z_$][a-zA-Z0-9_$]*)' +
+          // void fnName
+          // (arg1, arg2)
+          '\\s*(?::(?P<args>.*))?'
+    );
 
-  const matches = xregexp.exec(line, regex);
-  if (matches == null) { return null; }
+    const matches = xregexp.exec(line, regex);
+    if (matches == null) { return null; }
 
-  let name = matches.name;
-  const argStr = matches.args;
-  const args = [];
-  let result;
+    let name = matches.name;
+    const argStr = matches.args;
+    const args = [];
+    let result;
 
-  if (argStr) {
-    regex = /\s*:\s*/g;
-    const groups = argStr.split(regex);
-    const numGroups = groups.length;
-    for (let i = 0; i < numGroups; i++) {
-      let group = groups[i];
-      if (i < (numGroups - 1)) {
-        regex = /\s+(\S*)$/g;
-        result = group.exec(regex);
-        name += ':' + result[1];
-        group = group.slice(0, result.index);
+    if (argStr) {
+      regex = /\s*:\s*/g;
+      const groups = argStr.split(regex);
+      const numGroups = groups.length;
+      for (let i = 0; i < numGroups; i++) {
+        let group = groups[i];
+        if (i < (numGroups - 1)) {
+          regex = /\s+(\S*)$/g;
+          result = group.exec(regex);
+          name += ':' + result[1];
+          group = group.slice(0, result.index);
+        }
+        args.push(group);
       }
-      args.push(group);
+      if (numGroups) { name += ':'; }
     }
-    if (numGroups) { name += ':'; }
+    return [name, args.join('|||'), matches.retval];
   }
-  return [name, args.join('|||'), matches.retval];
-};
 
-ObjCParser.prototype.parse_args = function (args) {
-  const out = [];
-  const argList = args.split('|||');
-  for (let i = 0; i < argList.length; i++) {
-    const arg = argList[i];
-    const lastParen = arg.lastIndexOf(')');
-    out.push(arg.split(1, lastParen), arg.split(lastParen + 1));
+  parse_args (args) {
+    const out = [];
+    const argList = args.split('|||');
+    for (let i = 0; i < argList.length; i++) {
+      const arg = argList[i];
+      const lastParen = arg.lastIndexOf(')');
+      out.push(arg.split(1, lastParen), arg.split(lastParen + 1));
+    }
+    return out;
   }
-  return out;
-};
 
-ObjCParser.prototype.get_function_return_type = function (name, retval) {
-  if ((retval !== 'void') && (retval !== 'IBAction')) { return retval; } else { return null; }
-};
+  get_function_return_type (name, retval) {
+    if ((retval !== 'void') && (retval !== 'IBAction')) { return retval; } else { return null; }
+  }
 
-ObjCParser.prototype.parse_var = function (line) {
-  return null;
+  parse_var (line) {
+    return null;
+  }
 };
-
-module.exports = ObjCParser;

--- a/lib/languages/php.js
+++ b/lib/languages/php.js
@@ -1,171 +1,169 @@
 const DocsParser = require('../docsparser');
 const xregexp = require('xregexp');
 
-class PhpParser extends DocsParser {}
-
-PhpParser.prototype.setup_settings = function () {
-  const shortPrimitives = this.editor_settings.short_primitives || false;
-  const nameToken = '[a-zA-Z_$\\x7f-\\xff][a-zA-Z0-9_$\\x7f-\\xff]*';
-  this.settings = {
-    commentType: 'block',
-    // curly brackets around the type information
-    curlyTypes: false,
-    typeInfo: true,
-    typeTag: 'var',
-    varIdentifier: nameToken + '(?:->' + nameToken + ')*',
-    fnIdentifier: nameToken,
-    classIdentifier: nameToken,
-    fnOpener: 'function(?:\\s+' + nameToken + ')?\\s*\\(',
-    commentCloser: ' */',
-    bool: (shortPrimitives ? 'bool' : 'boolean'),
-    function: 'function'
-  };
-};
-
-PhpParser.prototype.parse_class = function (line) {
-  const regex = xregexp(
-    '^\\s*class\\s+' +
-        '(?P<name>' + this.settings.classIdentifier + ')'
-  );
-
-  const matches = xregexp.exec(line, regex);
-  if (matches === null) { return null; }
-
-  return [matches.name];
-};
-
-PhpParser.prototype.parse_function = function (line) {
-  const r = '^\\s*(?:(?P<modifier>(?:(?:final\\s+)?(?:public|protected|private)\\s+)?(?:final\\s+)?(?:static\\s+)?))?' +
-            'function\\s+&?(?:\\s+)?' +
-            '(?P<name>' + this.settings.fnIdentifier + ')' +
-            // function fnName
-            // (arg1, arg2)
-            '\\s*\\(\\s*(?P<args>.*?)\\)' +
-            '(?:\\s*\\:\\s*(?P<retval>[a-zA-Z0-9_\\x5c]*))?';
-  const regex = xregexp(r);
-
-  const matches = xregexp.exec(line, regex);
-  if (matches === null) { return null; }
-
-  return [matches.name, (matches.args ? matches.args.trim() : null), (matches.retval ? matches.retval.trim() : null)];
-};
-
-PhpParser.prototype.get_arg_type = function (arg) {
-  // function add($x, $y = 1)
-  const regex = xregexp(
-    '(?P<name>' + this.settings.varIdentifier + ')\\s*=\\s*(?P<val>.*)'
-  );
-
-  let matches = xregexp.exec(arg, regex);
-  if (matches !== null) { return this.guess_type_from_value(matches.val); }
-
-  // function sum(Array $x)
-  if (arg.search(/\S\s/) > -1) {
-    matches = /^(\S+)/.exec(arg);
-    return matches[1];
-  } else { return null; }
-};
-
-PhpParser.prototype.get_arg_name = function (arg) {
-  const regex = new RegExp(
-    '(' + this.settings.varIdentifier + ')(?:\\s*=.*)?$'
-  );
-  const matches = regex.exec(arg);
-  return matches[1];
-};
-
-PhpParser.prototype.parse_var = function (line) {
-  /*
-        var $foo = blah,
-            $foo = blah;
-        $baz->foo = blah;
-        $baz = array(
-             'foo' => blah
-        )
-    */
-  const r = '^\\s*(?:(?P<modifier>var|static|const|(?:final)(?:public|private|protected)(?:\\s+final)(?:\\s+static)?)\\s+)?' +
-            '(?P<name>' + this.settings.varIdentifier + ')' +
-            '(?:\\s*=>?\\s*(?P<val>.*?)(?:[;,]|$))?';
-  const regex = xregexp(r);
-  const matches = xregexp.exec(line, regex);
-  if (matches !== null) { return [matches.name, (matches.val ? matches.val.trim() : null)]; }
-
-  return null;
-};
-
-PhpParser.prototype.guess_type_from_value = function (val) {
-  const shortPrimitives = this.editor_settings.short_primitives || false;
-  if (this.is_numeric(val)) {
-    if (val.indexOf('.') > -1) { return 'float'; }
-
-    return (shortPrimitives ? 'int' : 'integer');
-  }
-  if ((val[0] === '"') || (val[0] === '\'')) { return 'string'; }
-  if (val.slice(0, 5) === 'array' || val[0] === '[') { return 'array'; }
-
-  const values = ['true', 'false', 'filenotfound'];
-  if (values.indexOf(val.toLowerCase()) !== -1) {
-    return (shortPrimitives ? 'bool' : 'boolean');
+module.exports = class PhpParser extends DocsParser {
+  setup_settings () {
+    const shortPrimitives = this.editor_settings.short_primitives || false;
+    const nameToken = '[a-zA-Z_$\\x7f-\\xff][a-zA-Z0-9_$\\x7f-\\xff]*';
+    this.settings = {
+      commentType: 'block',
+      // curly brackets around the type information
+      curlyTypes: false,
+      typeInfo: true,
+      typeTag: 'var',
+      varIdentifier: nameToken + '(?:->' + nameToken + ')*',
+      fnIdentifier: nameToken,
+      classIdentifier: nameToken,
+      fnOpener: 'function(?:\\s+' + nameToken + ')?\\s*\\(',
+      commentCloser: ' */',
+      bool: (shortPrimitives ? 'bool' : 'boolean'),
+      function: 'function'
+    };
   }
 
-  if (val.slice(0, 4) === 'new ') {
-    const regex = new RegExp(
-      'new (' + this.settings.fnIdentifier + ')'
+  parse_class (line) {
+    const regex = xregexp(
+      '^\\s*class\\s+' +
+          '(?P<name>' + this.settings.classIdentifier + ')'
     );
-    const matches = regex.exec(val);
-    return (matches[0] && matches[1]) || null;
-  }
-  return null;
-};
 
-PhpParser.prototype.get_function_return_type = function (name, retval) {
-  const shortPrimitives = this.editor_settings.short_primitives || false;
-  if (name.slice(0, 2) === '__') {
-    const values = ['__construct', '__destruct', '__set', '__unset', '__wakeup'];
-    for (let i = 0; i < values.length; i++) {
-      if (name === values[i]) { return null; }
-    }
-    if (name === '__sleep') { return 'array'; }
-    if (name === '__toString') { return 'string'; }
-    if (name === '__isset') { return (shortPrimitives ? 'bool' : 'boolean'); }
-  } else if (retval === 'void') {
+    const matches = xregexp.exec(line, regex);
+    if (matches === null) { return null; }
+
+    return [matches.name];
+  }
+
+  parse_function (line) {
+    const r = '^\\s*(?:(?P<modifier>(?:(?:final\\s+)?(?:public|protected|private)\\s+)?(?:final\\s+)?(?:static\\s+)?))?' +
+              'function\\s+&?(?:\\s+)?' +
+              '(?P<name>' + this.settings.fnIdentifier + ')' +
+              // function fnName
+              // (arg1, arg2)
+              '\\s*\\(\\s*(?P<args>.*?)\\)' +
+              '(?:\\s*\\:\\s*(?P<retval>[a-zA-Z0-9_\\x5c]*))?';
+    const regex = xregexp(r);
+
+    const matches = xregexp.exec(line, regex);
+    if (matches === null) { return null; }
+
+    return [matches.name, (matches.args ? matches.args.trim() : null), (matches.retval ? matches.retval.trim() : null)];
+  }
+
+  get_arg_type (arg) {
+    // function add($x, $y = 1)
+    const regex = xregexp(
+      '(?P<name>' + this.settings.varIdentifier + ')\\s*=\\s*(?P<val>.*)'
+    );
+
+    let matches = xregexp.exec(arg, regex);
+    if (matches !== null) { return this.guess_type_from_value(matches.val); }
+
+    // function sum(Array $x)
+    if (arg.search(/\S\s/) > -1) {
+      matches = /^(\S+)/.exec(arg);
+      return matches[1];
+    } else { return null; }
+  }
+
+  get_arg_name (arg) {
+    const regex = new RegExp(
+      '(' + this.settings.varIdentifier + ')(?:\\s*=.*)?$'
+    );
+    const matches = regex.exec(arg);
+    return matches[1];
+  }
+
+  parse_var (line) {
+    /*
+          var $foo = blah,
+              $foo = blah;
+          $baz->foo = blah;
+          $baz = array(
+               'foo' => blah
+          )
+      */
+    const r = '^\\s*(?:(?P<modifier>var|static|const|(?:final)(?:public|private|protected)(?:\\s+final)(?:\\s+static)?)\\s+)?' +
+              '(?P<name>' + this.settings.varIdentifier + ')' +
+              '(?:\\s*=>?\\s*(?P<val>.*?)(?:[;,]|$))?';
+    const regex = xregexp(r);
+    const matches = xregexp.exec(line, regex);
+    if (matches !== null) { return [matches.name, (matches.val ? matches.val.trim() : null)]; }
+
     return null;
-  } else if (retval) {
-    return retval;
   }
-  return DocsParser.prototype.get_function_return_type.call(this, name, retval);
-};
 
-PhpParser.prototype.get_definition = function (editor, pos, readLine) {
-  const maxLines = 25;
+  guess_type_from_value (val) {
+    const shortPrimitives = this.editor_settings.short_primitives || false;
+    if (this.is_numeric(val)) {
+      if (val.indexOf('.') > -1) { return 'float'; }
 
-  let definition = '';
+      return (shortPrimitives ? 'int' : 'integer');
+    }
+    if ((val[0] === '"') || (val[0] === '\'')) { return 'string'; }
+    if (val.slice(0, 5) === 'array' || val[0] === '[') { return 'array'; }
 
-  let /* removedStrings, match, */ line;
-  for (let i = 0; i < maxLines; i++) {
-    line = readLine(editor, pos);
-    pos.row += 1;
-
-    // null, undefined or invaild
-    if (typeof line !== 'string') {
-      break;
+    const values = ['true', 'false', 'filenotfound'];
+    if (values.indexOf(val.toLowerCase()) !== -1) {
+      return (shortPrimitives ? 'bool' : 'boolean');
     }
 
-    line = line
-    // strip one line comments
-      .replace(/\/\/.*$/g, '')
-    // strip block comments
-      .replace(/\/\*.*?\*\//g, '');
-    // // strip strings
-    // .replace(/'(?:\\.|[^'])*'/g, '\'\'')
-    // .replace(/"(?:\\.|[^"])*"/g, '""')
-    // // strip leading whitespace
-    // .replace(/^\s+/, '');
-
-    definition += line;
+    if (val.slice(0, 4) === 'new ') {
+      const regex = new RegExp(
+        'new (' + this.settings.fnIdentifier + ')'
+      );
+      const matches = regex.exec(val);
+      return (matches[0] && matches[1]) || null;
+    }
+    return null;
   }
 
-  return definition;
-};
+  get_function_return_type (name, retval) {
+    const shortPrimitives = this.editor_settings.short_primitives || false;
+    if (name.slice(0, 2) === '__') {
+      const values = ['__construct', '__destruct', '__set', '__unset', '__wakeup'];
+      for (let i = 0; i < values.length; i++) {
+        if (name === values[i]) { return null; }
+      }
+      if (name === '__sleep') { return 'array'; }
+      if (name === '__toString') { return 'string'; }
+      if (name === '__isset') { return (shortPrimitives ? 'bool' : 'boolean'); }
+    } else if (retval === 'void') {
+      return null;
+    } else if (retval) {
+      return retval;
+    }
+    return super.get_function_return_type(name, retval);
+  }
 
-module.exports = PhpParser;
+  get_definition (editor, pos, readLine) {
+    const maxLines = 25;
+
+    let definition = '';
+
+    let /* removedStrings, match, */ line;
+    for (let i = 0; i < maxLines; i++) {
+      line = readLine(editor, pos);
+      pos.row += 1;
+
+      // null, undefined or invaild
+      if (typeof line !== 'string') {
+        break;
+      }
+
+      line = line
+      // strip one line comments
+        .replace(/\/\/.*$/g, '')
+      // strip block comments
+        .replace(/\/\*.*?\*\//g, '');
+      // // strip strings
+      // .replace(/'(?:\\.|[^'])*'/g, '\'\'')
+      // .replace(/"(?:\\.|[^"])*"/g, '""')
+      // // strip leading whitespace
+      // .replace(/^\s+/, '');
+
+      definition += line;
+    }
+
+    return definition;
+  }
+};

--- a/lib/languages/php.js
+++ b/lib/languages/php.js
@@ -1,11 +1,7 @@
 const DocsParser = require('../docsparser');
 const xregexp = require('xregexp');
 
-function PhpParser (settings) {
-  DocsParser.call(this, settings);
-}
-
-PhpParser.prototype = Object.create(DocsParser.prototype);
+class PhpParser extends DocsParser {}
 
 PhpParser.prototype.setup_settings = function () {
   const shortPrimitives = this.editor_settings.short_primitives || false;

--- a/lib/languages/php.js
+++ b/lib/languages/php.js
@@ -2,8 +2,8 @@ const DocsParser = require('../docsparser');
 const xregexp = require('xregexp');
 
 module.exports = class PhpParser extends DocsParser {
-  setup_settings () {
-    const shortPrimitives = this.editor_settings.short_primitives || false;
+  setupSettings () {
+    const shortPrimitives = this.editorSettings.short_primitives || false;
     const nameToken = '[a-zA-Z_$\\x7f-\\xff][a-zA-Z0-9_$\\x7f-\\xff]*';
     this.settings = {
       commentType: 'block',
@@ -21,7 +21,7 @@ module.exports = class PhpParser extends DocsParser {
     };
   }
 
-  parse_class (line) {
+  parseClass (line) {
     const regex = xregexp(
       '^\\s*class\\s+' +
           '(?P<name>' + this.settings.classIdentifier + ')'
@@ -33,7 +33,7 @@ module.exports = class PhpParser extends DocsParser {
     return [matches.name];
   }
 
-  parse_function (line) {
+  parseFunction (line) {
     const r = '^\\s*(?:(?P<modifier>(?:(?:final\\s+)?(?:public|protected|private)\\s+)?(?:final\\s+)?(?:static\\s+)?))?' +
               'function\\s+&?(?:\\s+)?' +
               '(?P<name>' + this.settings.fnIdentifier + ')' +
@@ -49,14 +49,14 @@ module.exports = class PhpParser extends DocsParser {
     return [matches.name, (matches.args ? matches.args.trim() : null), (matches.retval ? matches.retval.trim() : null)];
   }
 
-  get_arg_type (arg) {
+  getArgType (arg) {
     // function add($x, $y = 1)
     const regex = xregexp(
       '(?P<name>' + this.settings.varIdentifier + ')\\s*=\\s*(?P<val>.*)'
     );
 
     let matches = xregexp.exec(arg, regex);
-    if (matches !== null) { return this.guess_type_from_value(matches.val); }
+    if (matches !== null) { return this.guessTypeFromValue(matches.val); }
 
     // function sum(Array $x)
     if (arg.search(/\S\s/) > -1) {
@@ -65,7 +65,7 @@ module.exports = class PhpParser extends DocsParser {
     } else { return null; }
   }
 
-  get_arg_name (arg) {
+  getArgName (arg) {
     const regex = new RegExp(
       '(' + this.settings.varIdentifier + ')(?:\\s*=.*)?$'
     );
@@ -73,7 +73,7 @@ module.exports = class PhpParser extends DocsParser {
     return matches[1];
   }
 
-  parse_var (line) {
+  parseVar (line) {
     /*
           var $foo = blah,
               $foo = blah;
@@ -92,9 +92,9 @@ module.exports = class PhpParser extends DocsParser {
     return null;
   }
 
-  guess_type_from_value (val) {
-    const shortPrimitives = this.editor_settings.short_primitives || false;
-    if (this.is_numeric(val)) {
+  guessTypeFromValue (val) {
+    const shortPrimitives = this.editorSettings.short_primitives || false;
+    if (this.isNumeric(val)) {
       if (val.indexOf('.') > -1) { return 'float'; }
 
       return (shortPrimitives ? 'int' : 'integer');
@@ -117,8 +117,8 @@ module.exports = class PhpParser extends DocsParser {
     return null;
   }
 
-  get_function_return_type (name, retval) {
-    const shortPrimitives = this.editor_settings.short_primitives || false;
+  getFunctionReturnType (name, retval) {
+    const shortPrimitives = this.editorSettings.short_primitives || false;
     if (name.slice(0, 2) === '__') {
       const values = ['__construct', '__destruct', '__set', '__unset', '__wakeup'];
       for (let i = 0; i < values.length; i++) {
@@ -132,10 +132,10 @@ module.exports = class PhpParser extends DocsParser {
     } else if (retval) {
       return retval;
     }
-    return super.get_function_return_type(name, retval);
+    return super.getFunctionReturnType(name, retval);
   }
 
-  get_definition (editor, pos, readLine) {
+  getDefinition (editor, pos, readLine) {
     const maxLines = 25;
 
     let definition = '';

--- a/lib/languages/processing.js
+++ b/lib/languages/processing.js
@@ -1,8 +1,3 @@
-var JavaParser = require('./java');
+const JavaParser = require('./java');
 
-function ProcessingParser (settings) {
-  JavaParser.call(this, settings);
-}
-ProcessingParser.prototype = Object.create(JavaParser.prototype);
-
-module.exports = ProcessingParser;
+module.exports = class ProcessingParser extends JavaParser {};

--- a/lib/languages/rust.js
+++ b/lib/languages/rust.js
@@ -2,7 +2,7 @@ const DocsParser = require('../docsparser');
 const xregexp = require('xregexp');
 
 module.exports = class RustParser extends DocsParser {
-  setup_settings () {
+  setupSettings () {
     this.settings = {
       commentType: 'block',
       curlyTypes: false,
@@ -17,7 +17,7 @@ module.exports = class RustParser extends DocsParser {
     };
   }
 
-  parse_function (line) {
+  parseFunction (line) {
     // TODO: add regexp for closures syntax
     // TODO: parse params
     const regex = xregexp('\\s*fn\\s+(?P<name>' + this.settings.fnIdentifier + ')');
@@ -30,7 +30,7 @@ module.exports = class RustParser extends DocsParser {
     return [name, null];
   }
 
-  parse_var (line) {
+  parseVar (line) {
     // TODO: add support for struct and tuple destructuring
     // TODO: parse type and value
     const regex = xregexp('\\s*let\\s+(mut\\s+)?(?P<name>' + this.settings.varIdentifier + ')');
@@ -44,11 +44,11 @@ module.exports = class RustParser extends DocsParser {
     return [name, null, null];
   }
 
-  format_function (name, args) {
+  formatFunction (name, args) {
     return [name];
   }
 
-  format_var (name, val, valType) {
+  formatVar (name, val, valType) {
     return [name];
   }
 };

--- a/lib/languages/rust.js
+++ b/lib/languages/rust.js
@@ -1,11 +1,7 @@
 const DocsParser = require('../docsparser');
 const xregexp = require('xregexp');
 
-function RustParser (settings) {
-  DocsParser.call(this, settings);
-}
-
-RustParser.prototype = Object.create(DocsParser.prototype);
+class RustParser extends DocsParser {}
 
 RustParser.prototype.setup_settings = function () {
   this.settings = {

--- a/lib/languages/rust.js
+++ b/lib/languages/rust.js
@@ -1,56 +1,54 @@
 const DocsParser = require('../docsparser');
 const xregexp = require('xregexp');
 
-class RustParser extends DocsParser {}
-
-RustParser.prototype.setup_settings = function () {
-  this.settings = {
-    commentType: 'block',
-    curlyTypes: false,
-    typeInfo: false,
-    typeTag: false,
-    varIdentifier: '[a-zA-Z_][a-zA-Z_0-9]*',
-    fnIdentifier: '[a-zA-Z_][a-zA-Z_0-9]*',
-    fnOpener: '^\\s*fn',
-    commentCloser: ' */',
-    bool: 'bool',
-    function: 'fn'
-  };
-};
-
-RustParser.prototype.parse_function = function (line) {
-  // TODO: add regexp for closures syntax
-  // TODO: parse params
-  const regex = xregexp('\\s*fn\\s+(?P<name>' + this.settings.fnIdentifier + ')');
-
-  const matches = xregexp.exec(line, regex);
-  if (matches === null || matches.name === undefined) {
-    return null;
-  }
-  const name = matches.name;
-  return [name, null];
-};
-
-RustParser.prototype.parse_var = function (line) {
-  // TODO: add support for struct and tuple destructuring
-  // TODO: parse type and value
-  const regex = xregexp('\\s*let\\s+(mut\\s+)?(?P<name>' + this.settings.varIdentifier + ')');
-
-  const matches = xregexp.exec(line, regex);
-  if (matches === null || matches.name === undefined) {
-    return null;
+module.exports = class RustParser extends DocsParser {
+  setup_settings () {
+    this.settings = {
+      commentType: 'block',
+      curlyTypes: false,
+      typeInfo: false,
+      typeTag: false,
+      varIdentifier: '[a-zA-Z_][a-zA-Z_0-9]*',
+      fnIdentifier: '[a-zA-Z_][a-zA-Z_0-9]*',
+      fnOpener: '^\\s*fn',
+      commentCloser: ' */',
+      bool: 'bool',
+      function: 'fn'
+    };
   }
 
-  const name = matches.name;
-  return [name, null, null];
-};
+  parse_function (line) {
+    // TODO: add regexp for closures syntax
+    // TODO: parse params
+    const regex = xregexp('\\s*fn\\s+(?P<name>' + this.settings.fnIdentifier + ')');
 
-RustParser.prototype.format_function = function (name, args) {
-  return [name];
-};
+    const matches = xregexp.exec(line, regex);
+    if (matches === null || matches.name === undefined) {
+      return null;
+    }
+    const name = matches.name;
+    return [name, null];
+  }
 
-RustParser.prototype.format_var = function (name, val, valType) {
-  return [name];
-};
+  parse_var (line) {
+    // TODO: add support for struct and tuple destructuring
+    // TODO: parse type and value
+    const regex = xregexp('\\s*let\\s+(mut\\s+)?(?P<name>' + this.settings.varIdentifier + ')');
 
-module.exports = RustParser;
+    const matches = xregexp.exec(line, regex);
+    if (matches === null || matches.name === undefined) {
+      return null;
+    }
+
+    const name = matches.name;
+    return [name, null, null];
+  }
+
+  format_function (name, args) {
+    return [name];
+  }
+
+  format_var (name, val, valType) {
+    return [name];
+  }
+};

--- a/lib/languages/sass.js
+++ b/lib/languages/sass.js
@@ -2,160 +2,158 @@ const util = require('util');
 const DocsParser = require('../docsparser');
 const xregexp = require('xregexp');
 
-class SassParser extends DocsParser {}
+module.exports = class SassParser extends DocsParser {
+  setup_settings () {
+    const identifier = '[a-zA-Z_-][a-zA-Z_0-9-]*';
+    this.settings = {
+      commentType: 'single',
+      curlyTypes: true,
+      typeInfo: true,
+      typeTag: 'type',
+      prefix: '///',
+      varIdentifier: '\\$' + identifier,
+      fnIdentifier: identifier,
+      fnOpener: '@(?:mixin|function)\\s+' + identifier + '\\s*[\\(|\\{]',
+      bool: 'Boolean'
+    };
+  }
 
-SassParser.prototype.setup_settings = function () {
-  const identifier = '[a-zA-Z_-][a-zA-Z_0-9-]*';
-  this.settings = {
-    commentType: 'single',
-    curlyTypes: true,
-    typeInfo: true,
-    typeTag: 'type',
-    prefix: '///',
-    varIdentifier: '\\$' + identifier,
-    fnIdentifier: identifier,
-    fnOpener: '@(?:mixin|function)\\s+' + identifier + '\\s*[\\(|\\{]',
-    bool: 'Boolean'
-  };
-};
+  parse_function (line) {
+    const r = '^\\s*@(?P<fnType>(mixin|function))\\s+' +
+          '(?P<name>' + this.settings.fnIdentifier + ')' +
+          '\\s*(?:\\(\\s*(?P<args>.*?)\\)|{)';
+    const regex = xregexp(r);
 
-SassParser.prototype.parse_function = function (line) {
-  const r = '^\\s*@(?P<fnType>(mixin|function))\\s+' +
-        '(?P<name>' + this.settings.fnIdentifier + ')' +
-        '\\s*(?:\\(\\s*(?P<args>.*?)\\)|{)';
-  const regex = xregexp(r);
+    const matches = xregexp.exec(line, regex);
+    if (matches === null) { return null; }
 
-  const matches = xregexp.exec(line, regex);
-  if (matches === null) { return null; }
+    return [
+      matches.name,
+      (matches.args ? matches.args.trim() : null),
+      (matches.fnType === 'mixin' ? null : false)
+    ];
+  }
 
-  return [
-    matches.name,
-    (matches.args ? matches.args.trim() : null),
-    (matches.fnType === 'mixin' ? null : false)
-  ];
-};
+  parse_var (line) {
+    //   $foo: blah;
+    const r = '(?P<name>' + this.settings.varIdentifier + ')' +
+          '\\s*:\\s*(?P<val>.*?)(?:;|$)';
+    const regex = xregexp(r);
 
-SassParser.prototype.parse_var = function (line) {
-  //   $foo: blah;
-  const r = '(?P<name>' + this.settings.varIdentifier + ')' +
-        '\\s*:\\s*(?P<val>.*?)(?:;|$)';
-  const regex = xregexp(r);
+    const matches = xregexp.exec(line, regex);
 
-  const matches = xregexp.exec(line, regex);
+    if (matches === null) {
+      return null;
+    }
+    // variable name, variable value
+    return [matches.name, matches.val.trim()];
+  }
 
-  if (matches === null) {
+  parse_arg (arg) {
+    const regex = xregexp(
+      '(?P<name>' + this.settings.varIdentifier + ')(\\s*:\\s*(?P<value>.*))?'
+    );
+
+    return xregexp.exec(arg, regex);
+  }
+
+  get_arg_type (arg) {
+    const matches = this.parse_arg(arg);
+
+    if (matches && matches.value) {
+      return this.guess_type_from_value(matches.value);
+    }
+
     return null;
   }
-  // variable name, variable value
-  return [matches.name, matches.val.trim()];
+
+  get_arg_name (arg) {
+    const matches = this.parse_arg(arg);
+
+    if (matches && matches.value) {
+      return util.format('%s [%s]', matches.name, matches.value);
+    } else if (matches && matches.name) {
+      return matches.name;
+    }
+
+    // a invalid name was passed
+    return null;
+  }
+
+  guess_type_from_value (val) {
+    const shortPrimitives = this.editor_settings.short_primitives || false;
+
+    // It doesn't detect string without quotes, because it could be a color name
+    // It doesn't detect empty lists or maps, because they have the same syntax
+
+    if (this.is_map(val)) {
+      return 'map';
+    }
+    if (this.is_list(val)) {
+      return 'list';
+    }
+    if (this.is_numeric(val[0])) {
+      return 'number';
+    }
+    if ((val[0] === '\'') || (val[0] === '"')) {
+      return 'string';
+    }
+    if (val === 'null') {
+      return 'null';
+    }
+    if ((val === 'true') || (val === 'false')) {
+      return (shortPrimitives ? 'Bool' : 'Boolean');
+    }
+    if (this.is_color(val)) {
+      return 'color';
+    }
+
+    return null;
+  }
+
+  get_function_return_type (name, retval) {
+    if (retval) {
+      return retval;
+    }
+
+    return super.get_function_return_type(name, retval);
+  }
+
+  is_color (val) {
+    const expr = new RegExp('^(' +
+          // #FFF
+          '#[0-9a-f]{3}' +
+          '|' +
+          // #EFEFEF
+          // #02060901
+          '#(?:[0-9a-f]{2}){2,4}' +
+          '|' +
+          // rgb(0,0,0)
+          // hsla(0,0,0,0)
+          // hsl(0,0,0,0)
+          // rgba(0,0,0)
+          '(rgb|hsl)a?\\((-?\\d+%?[,\\s]+){2,3}\\s*[\\d\\.]+%?\\))' +
+          '$', 'i');
+    return expr.test(val);
+  }
+
+  is_map (val) {
+    const expr = new RegExp('^\\(\\s*' + this.settings.fnIdentifier + '\\s*:');
+    return expr.test(val);
+  }
+
+  is_list (val) {
+    const expr = new RegExp('^(' +
+          // [example, list]
+          '\\[' +
+          '|' +
+          // (example, list)
+          '\\(' +
+          ')?' +
+          // example list
+          // example, list
+          '[a-zA-Z_0-9$][a-zA-Z_0-9-]*([,\\s]+[a-zA-Z_0-9$][a-zA-Z_0-9-]*)+' +
+          '(\\]|\\))?$');
+    return expr.test(val);
+  }
 };
-
-SassParser.prototype.parse_arg = function (arg) {
-  const regex = xregexp(
-    '(?P<name>' + this.settings.varIdentifier + ')(\\s*:\\s*(?P<value>.*))?'
-  );
-
-  return xregexp.exec(arg, regex);
-};
-
-SassParser.prototype.get_arg_type = function (arg) {
-  const matches = this.parse_arg(arg);
-
-  if (matches && matches.value) {
-    return this.guess_type_from_value(matches.value);
-  }
-
-  return null;
-};
-
-SassParser.prototype.get_arg_name = function (arg) {
-  const matches = this.parse_arg(arg);
-
-  if (matches && matches.value) {
-    return util.format('%s [%s]', matches.name, matches.value);
-  } else if (matches && matches.name) {
-    return matches.name;
-  }
-
-  // a invalid name was passed
-  return null;
-};
-
-SassParser.prototype.guess_type_from_value = function (val) {
-  const shortPrimitives = this.editor_settings.short_primitives || false;
-
-  // It doesn't detect string without quotes, because it could be a color name
-  // It doesn't detect empty lists or maps, because they have the same syntax
-
-  if (this.is_map(val)) {
-    return 'map';
-  }
-  if (this.is_list(val)) {
-    return 'list';
-  }
-  if (this.is_numeric(val[0])) {
-    return 'number';
-  }
-  if ((val[0] === '\'') || (val[0] === '"')) {
-    return 'string';
-  }
-  if (val === 'null') {
-    return 'null';
-  }
-  if ((val === 'true') || (val === 'false')) {
-    return (shortPrimitives ? 'Bool' : 'Boolean');
-  }
-  if (this.is_color(val)) {
-    return 'color';
-  }
-
-  return null;
-};
-
-SassParser.prototype.get_function_return_type = function (name, retval) {
-  if (retval) {
-    return retval;
-  }
-
-  return DocsParser.prototype.get_function_return_type.call(this, name, retval);
-};
-
-SassParser.prototype.is_color = function (val) {
-  const expr = new RegExp('^(' +
-        // #FFF
-        '#[0-9a-f]{3}' +
-        '|' +
-        // #EFEFEF
-        // #02060901
-        '#(?:[0-9a-f]{2}){2,4}' +
-        '|' +
-        // rgb(0,0,0)
-        // hsla(0,0,0,0)
-        // hsl(0,0,0,0)
-        // rgba(0,0,0)
-        '(rgb|hsl)a?\\((-?\\d+%?[,\\s]+){2,3}\\s*[\\d\\.]+%?\\))' +
-        '$', 'i');
-  return expr.test(val);
-};
-
-SassParser.prototype.is_map = function (val) {
-  const expr = new RegExp('^\\(\\s*' + this.settings.fnIdentifier + '\\s*:');
-  return expr.test(val);
-};
-
-SassParser.prototype.is_list = function (val) {
-  const expr = new RegExp('^(' +
-        // [example, list]
-        '\\[' +
-        '|' +
-        // (example, list)
-        '\\(' +
-        ')?' +
-        // example list
-        // example, list
-        '[a-zA-Z_0-9$][a-zA-Z_0-9-]*([,\\s]+[a-zA-Z_0-9$][a-zA-Z_0-9-]*)+' +
-        '(\\]|\\))?$');
-  return expr.test(val);
-};
-
-module.exports = SassParser;

--- a/lib/languages/sass.js
+++ b/lib/languages/sass.js
@@ -3,7 +3,7 @@ const DocsParser = require('../docsparser');
 const xregexp = require('xregexp');
 
 module.exports = class SassParser extends DocsParser {
-  setup_settings () {
+  setupSettings () {
     const identifier = '[a-zA-Z_-][a-zA-Z_0-9-]*';
     this.settings = {
       commentType: 'single',
@@ -18,7 +18,7 @@ module.exports = class SassParser extends DocsParser {
     };
   }
 
-  parse_function (line) {
+  parseFunction (line) {
     const r = '^\\s*@(?P<fnType>(mixin|function))\\s+' +
           '(?P<name>' + this.settings.fnIdentifier + ')' +
           '\\s*(?:\\(\\s*(?P<args>.*?)\\)|{)';
@@ -34,7 +34,7 @@ module.exports = class SassParser extends DocsParser {
     ];
   }
 
-  parse_var (line) {
+  parseVar (line) {
     //   $foo: blah;
     const r = '(?P<name>' + this.settings.varIdentifier + ')' +
           '\\s*:\\s*(?P<val>.*?)(?:;|$)';
@@ -49,7 +49,7 @@ module.exports = class SassParser extends DocsParser {
     return [matches.name, matches.val.trim()];
   }
 
-  parse_arg (arg) {
+  parseArg (arg) {
     const regex = xregexp(
       '(?P<name>' + this.settings.varIdentifier + ')(\\s*:\\s*(?P<value>.*))?'
     );
@@ -57,18 +57,18 @@ module.exports = class SassParser extends DocsParser {
     return xregexp.exec(arg, regex);
   }
 
-  get_arg_type (arg) {
-    const matches = this.parse_arg(arg);
+  getArgType (arg) {
+    const matches = this.parseArg(arg);
 
     if (matches && matches.value) {
-      return this.guess_type_from_value(matches.value);
+      return this.guessTypeFromValue(matches.value);
     }
 
     return null;
   }
 
-  get_arg_name (arg) {
-    const matches = this.parse_arg(arg);
+  getArgName (arg) {
+    const matches = this.parseArg(arg);
 
     if (matches && matches.value) {
       return util.format('%s [%s]', matches.name, matches.value);
@@ -80,19 +80,19 @@ module.exports = class SassParser extends DocsParser {
     return null;
   }
 
-  guess_type_from_value (val) {
-    const shortPrimitives = this.editor_settings.short_primitives || false;
+  guessTypeFromValue (val) {
+    const shortPrimitives = this.editorSettings.short_primitives || false;
 
     // It doesn't detect string without quotes, because it could be a color name
     // It doesn't detect empty lists or maps, because they have the same syntax
 
-    if (this.is_map(val)) {
+    if (this.isMap(val)) {
       return 'map';
     }
-    if (this.is_list(val)) {
+    if (this.isList(val)) {
       return 'list';
     }
-    if (this.is_numeric(val[0])) {
+    if (this.isNumeric(val[0])) {
       return 'number';
     }
     if ((val[0] === '\'') || (val[0] === '"')) {
@@ -104,22 +104,22 @@ module.exports = class SassParser extends DocsParser {
     if ((val === 'true') || (val === 'false')) {
       return (shortPrimitives ? 'Bool' : 'Boolean');
     }
-    if (this.is_color(val)) {
+    if (this.isColor(val)) {
       return 'color';
     }
 
     return null;
   }
 
-  get_function_return_type (name, retval) {
+  getFunctionReturnType (name, retval) {
     if (retval) {
       return retval;
     }
 
-    return super.get_function_return_type(name, retval);
+    return super.getFunctionReturnType(name, retval);
   }
 
-  is_color (val) {
+  isColor (val) {
     const expr = new RegExp('^(' +
           // #FFF
           '#[0-9a-f]{3}' +
@@ -137,12 +137,12 @@ module.exports = class SassParser extends DocsParser {
     return expr.test(val);
   }
 
-  is_map (val) {
+  isMap (val) {
     const expr = new RegExp('^\\(\\s*' + this.settings.fnIdentifier + '\\s*:');
     return expr.test(val);
   }
 
-  is_list (val) {
+  isList (val) {
     const expr = new RegExp('^(' +
           // [example, list]
           '\\[' +

--- a/lib/languages/sass.js
+++ b/lib/languages/sass.js
@@ -2,13 +2,7 @@ const util = require('util');
 const DocsParser = require('../docsparser');
 const xregexp = require('xregexp');
 
-function SassParser (settings) {
-  // this.setup_settings();
-  // call parent constructor
-  DocsParser.call(this, settings);
-}
-
-SassParser.prototype = Object.create(DocsParser.prototype);
+class SassParser extends DocsParser {}
 
 SassParser.prototype.setup_settings = function () {
   const identifier = '[a-zA-Z_-][a-zA-Z_0-9-]*';

--- a/lib/languages/typescript.js
+++ b/lib/languages/typescript.js
@@ -2,11 +2,7 @@ const DocsParser = require('../docsparser');
 const xregexp = require('xregexp');
 const util = require('util');
 
-function TypescriptParser (settings) {
-  DocsParser.call(this, settings);
-}
-
-TypescriptParser.prototype = Object.create(DocsParser.prototype);
+class TypescriptParser extends DocsParser {}
 
 TypescriptParser.prototype.setup_settings = function () {
   const identifier = '[a-zA-Z_$][a-zA-Z_$0-9]*';

--- a/lib/languages/typescript.js
+++ b/lib/languages/typescript.js
@@ -3,7 +3,7 @@ const xregexp = require('xregexp');
 const util = require('util');
 
 module.exports = class TypescriptParser extends DocsParser {
-  setup_settings () {
+  setupSettings () {
     const identifier = '[a-zA-Z_$][a-zA-Z_$0-9]*';
     const baseTypeIdentifier = util.format('%s(\\.%s)*(\\[\\])?', identifier, identifier);
     const parametricTypeIdentifier = util.format('%s(\\s*<\\s*%s(\\s*,\\s*%s\\s*)*>)?', baseTypeIdentifier, baseTypeIdentifier, baseTypeIdentifier);
@@ -36,7 +36,7 @@ module.exports = class TypescriptParser extends DocsParser {
     };
   }
 
-  parse_function (line) {
+  parseFunction (line) {
     line = line.trim();
     const regex = xregexp(this.settings.functionRE);
     const matches = xregexp.exec(line, regex);
@@ -45,7 +45,7 @@ module.exports = class TypescriptParser extends DocsParser {
     return [matches.name, matches.args, matches.retval];
   }
 
-  get_arg_type (arg) {
+  getArgType (arg) {
     if (arg.indexOf(':') > -1) {
       const argList = arg.split(':');
       return argList[argList.length - 1].trim();
@@ -53,7 +53,7 @@ module.exports = class TypescriptParser extends DocsParser {
     return null;
   }
 
-  get_arg_name (arg) {
+  getArgName (arg) {
     if (arg.indexOf(':') > -1) { arg = arg.split(':')[0]; }
 
     const pubPrivPattern = /\b(public|private)\s+|/g;
@@ -63,7 +63,7 @@ module.exports = class TypescriptParser extends DocsParser {
     return arg.replace(regex, '');
   }
 
-  parse_var (line) {
+  parseVar (line) {
     const regex = xregexp(this.settings.var_re);
     const matches = xregexp.exec(line, regex);
     if (matches == null) { return null; }
@@ -73,16 +73,16 @@ module.exports = class TypescriptParser extends DocsParser {
     return [matches.name, val, matches.type];
   }
 
-  get_function_return_type (name, retval) {
+  getFunctionReturnType (name, retval) {
     if (name === 'constructor') {
       return null;
     }
     return ((retval !== 'void') ? retval : null);
   }
 
-  guess_type_from_value (val) {
-    const lowerPrimitives = this.editor_settings.lower_case_primitives || false;
-    if (this.is_numeric(val)) { return (lowerPrimitives ? 'number' : 'Number'); }
+  guessTypeFromValue (val) {
+    const lowerPrimitives = this.editorSettings.lower_case_primitives || false;
+    if (this.isNumeric(val)) { return (lowerPrimitives ? 'number' : 'Number'); }
     if ((val[0] === '\'') || (val[0] === '"')) { return (lowerPrimitives ? 'string' : 'String'); }
     if (val[0] === '[') { return 'Array'; }
     if (val[0] === '{') { return 'Object'; }

--- a/lib/languages/typescript.js
+++ b/lib/languages/typescript.js
@@ -2,104 +2,102 @@ const DocsParser = require('../docsparser');
 const xregexp = require('xregexp');
 const util = require('util');
 
-class TypescriptParser extends DocsParser {}
-
-TypescriptParser.prototype.setup_settings = function () {
-  const identifier = '[a-zA-Z_$][a-zA-Z_$0-9]*';
-  const baseTypeIdentifier = util.format('%s(\\.%s)*(\\[\\])?', identifier, identifier);
-  const parametricTypeIdentifier = util.format('%s(\\s*<\\s*%s(\\s*,\\s*%s\\s*)*>)?', baseTypeIdentifier, baseTypeIdentifier, baseTypeIdentifier);
-  this.settings = {
-    commentType: 'block',
-    // curly brackets around the type information
-    curlyTypes: true,
-    typeInfo: false,
-    typeTag: 'type',
-    // technically, they can contain all sorts of unicode, but w/e
-    varIdentifier: identifier,
-    fnIdentifier: identifier,
-    fnOpener: 'function(?:\\s+' + identifier + ')?\\s*\\(',
-    commentCloser: ' */',
-    bool: 'Boolean',
-    function: 'Function',
-    functionRE:
-            // Modifiers
-            '(?:public|private|static)?\\s*' +
-            // Method name
-            '(?P<name>' + identifier + ')\\s*' +
-            // Params
-            '\\((?P<args>.*?)\\)\\s*' +
-            // Return value
-            '(:\\s*(?P<retval>' + parametricTypeIdentifier + '))?',
-    var_re:
-            '((public|private|static|var)\\s+)?(?P<name>' + identifier +
-            ')\\s*(:\\s*(?P<type>' + parametricTypeIdentifier +
-            '))?(\\s*=\\s*(?P<val>.*?))?([;,]|$)'
-  };
-};
-
-TypescriptParser.prototype.parse_function = function (line) {
-  line = line.trim();
-  const regex = xregexp(this.settings.functionRE);
-  const matches = xregexp.exec(line, regex);
-  if (matches === null) { return null; }
-
-  return [matches.name, matches.args, matches.retval];
-};
-
-TypescriptParser.prototype.get_arg_type = function (arg) {
-  if (arg.indexOf(':') > -1) {
-    const argList = arg.split(':');
-    return argList[argList.length - 1].trim();
+module.exports = class TypescriptParser extends DocsParser {
+  setup_settings () {
+    const identifier = '[a-zA-Z_$][a-zA-Z_$0-9]*';
+    const baseTypeIdentifier = util.format('%s(\\.%s)*(\\[\\])?', identifier, identifier);
+    const parametricTypeIdentifier = util.format('%s(\\s*<\\s*%s(\\s*,\\s*%s\\s*)*>)?', baseTypeIdentifier, baseTypeIdentifier, baseTypeIdentifier);
+    this.settings = {
+      commentType: 'block',
+      // curly brackets around the type information
+      curlyTypes: true,
+      typeInfo: false,
+      typeTag: 'type',
+      // technically, they can contain all sorts of unicode, but w/e
+      varIdentifier: identifier,
+      fnIdentifier: identifier,
+      fnOpener: 'function(?:\\s+' + identifier + ')?\\s*\\(',
+      commentCloser: ' */',
+      bool: 'Boolean',
+      function: 'Function',
+      functionRE:
+              // Modifiers
+              '(?:public|private|static)?\\s*' +
+              // Method name
+              '(?P<name>' + identifier + ')\\s*' +
+              // Params
+              '\\((?P<args>.*?)\\)\\s*' +
+              // Return value
+              '(:\\s*(?P<retval>' + parametricTypeIdentifier + '))?',
+      var_re:
+              '((public|private|static|var)\\s+)?(?P<name>' + identifier +
+              ')\\s*(:\\s*(?P<type>' + parametricTypeIdentifier +
+              '))?(\\s*=\\s*(?P<val>.*?))?([;,]|$)'
+    };
   }
-  return null;
-};
 
-TypescriptParser.prototype.get_arg_name = function (arg) {
-  if (arg.indexOf(':') > -1) { arg = arg.split(':')[0]; }
+  parse_function (line) {
+    line = line.trim();
+    const regex = xregexp(this.settings.functionRE);
+    const matches = xregexp.exec(line, regex);
+    if (matches === null) { return null; }
 
-  const pubPrivPattern = /\b(public|private)\s+|/g;
-  arg = arg.replace(pubPrivPattern, '');
+    return [matches.name, matches.args, matches.retval];
+  }
 
-  const regex = /[ ?]/g;
-  return arg.replace(regex, '');
-};
-
-TypescriptParser.prototype.parse_var = function (line) {
-  const regex = xregexp(this.settings.var_re);
-  const matches = xregexp.exec(line, regex);
-  if (matches == null) { return null; }
-  let val = matches.val;
-  if (val != null) { val = val.trim(); }
-
-  return [matches.name, val, matches.type];
-};
-
-TypescriptParser.prototype.get_function_return_type = function (name, retval) {
-  if (name === 'constructor') {
+  get_arg_type (arg) {
+    if (arg.indexOf(':') > -1) {
+      const argList = arg.split(':');
+      return argList[argList.length - 1].trim();
+    }
     return null;
   }
-  return ((retval !== 'void') ? retval : null);
-};
 
-TypescriptParser.prototype.guess_type_from_value = function (val) {
-  const lowerPrimitives = this.editor_settings.lower_case_primitives || false;
-  if (this.is_numeric(val)) { return (lowerPrimitives ? 'number' : 'Number'); }
-  if ((val[0] === '\'') || (val[0] === '"')) { return (lowerPrimitives ? 'string' : 'String'); }
-  if (val[0] === '[') { return 'Array'; }
-  if (val[0] === '{') { return 'Object'; }
-  if ((val === 'true') || (val === 'false')) { return (lowerPrimitives ? 'boolean' : 'Boolean'); }
-  let regex = new RegExp('RegExp\\b|\\/[^\\/]');
-  if (regex.test(val)) {
-    return 'RegExp';
-  }
-  if (val.slice(0, 4) === 'new ') {
-    regex = new RegExp(
-      'new (' + this.settings.fnIdentifier + ')'
-    );
-    const matches = regex.exec(val);
-    return (matches[0] && matches[1]) || null;
-  }
-  return null;
-};
+  get_arg_name (arg) {
+    if (arg.indexOf(':') > -1) { arg = arg.split(':')[0]; }
 
-module.exports = TypescriptParser;
+    const pubPrivPattern = /\b(public|private)\s+|/g;
+    arg = arg.replace(pubPrivPattern, '');
+
+    const regex = /[ ?]/g;
+    return arg.replace(regex, '');
+  }
+
+  parse_var (line) {
+    const regex = xregexp(this.settings.var_re);
+    const matches = xregexp.exec(line, regex);
+    if (matches == null) { return null; }
+    let val = matches.val;
+    if (val != null) { val = val.trim(); }
+
+    return [matches.name, val, matches.type];
+  }
+
+  get_function_return_type (name, retval) {
+    if (name === 'constructor') {
+      return null;
+    }
+    return ((retval !== 'void') ? retval : null);
+  }
+
+  guess_type_from_value (val) {
+    const lowerPrimitives = this.editor_settings.lower_case_primitives || false;
+    if (this.is_numeric(val)) { return (lowerPrimitives ? 'number' : 'Number'); }
+    if ((val[0] === '\'') || (val[0] === '"')) { return (lowerPrimitives ? 'string' : 'String'); }
+    if (val[0] === '[') { return 'Array'; }
+    if (val[0] === '{') { return 'Object'; }
+    if ((val === 'true') || (val === 'false')) { return (lowerPrimitives ? 'boolean' : 'Boolean'); }
+    let regex = new RegExp('RegExp\\b|\\/[^\\/]');
+    if (regex.test(val)) {
+      return 'RegExp';
+    }
+    if (val.slice(0, 4) === 'new ') {
+      regex = new RegExp(
+        'new (' + this.settings.fnIdentifier + ')'
+      );
+      const matches = regex.exec(val);
+      return (matches[0] && matches[1]) || null;
+    }
+    return null;
+  }
+};

--- a/spec/dataset/languages/cpp.yaml
+++ b/spec/dataset/languages/cpp.yaml
@@ -1,6 +1,6 @@
 name: CppParser
 
-parse_function:
+parseFunction:
     -
         - should parse a simple method
         - void foo() {}
@@ -38,7 +38,7 @@ parse_function:
         - Foo::Foo(int bar, char baz) {}
         - ['Foo::Foo', 'int bar, char baz', null]
 
-get_function_return_type:
+getFunctionReturnType:
     -
         - should return `null` because `void` methods have no return type
         - ['fooBar', 'void']
@@ -48,7 +48,7 @@ get_function_return_type:
         - ['fooBar', 'string']
         - 'string'
 
-get_arg_type:
+getArgType:
     -
         - should return arg's type when it's a simple primitive
         - char foo
@@ -57,7 +57,7 @@ get_arg_type:
         - should return arg's type even for an array
         - char foo []
         - 'char[]'
-get_arg_name:
+getArgName:
     -
         - should return arg's name for a simple case
         - char foo

--- a/spec/dataset/languages/java.yaml
+++ b/spec/dataset/languages/java.yaml
@@ -1,6 +1,6 @@
 name: JavaParser
 
-parse_function:
+parseFunction:
     -
         - should parse a simple method
         - void foo() {}
@@ -31,7 +31,7 @@ parse_function:
         - ['foo', null, 'char[]', null]
 
 
-get_function_return_type:
+getFunctionReturnType:
     -
         - should return `null` because `void` methods have no return
         - ['fooBar', 'void']

--- a/spec/dataset/languages/javascript.yaml
+++ b/spec/dataset/languages/javascript.yaml
@@ -1,6 +1,6 @@
 name: JsParser
 
-parse_function:
+parseFunction:
     -
         - should parse anonymous function
         - function() {}
@@ -193,7 +193,7 @@ parse_function:
     -
         - should treat functions with uppercase name as constructor
         - function Bar() {}
-        - ['Bar', null, null, {is_constructor: true}]
+        - ['Bar', null, null, {isConstructor: true}]
     -
         - should not treat arrow functions with uppercase name as constructor
         - Bar = () => {}
@@ -205,7 +205,7 @@ parse_function:
 
 
 
-get_arg_type:
+getArgType:
     -
         - should return no type
         - foo
@@ -275,7 +275,7 @@ get_arg_type:
         - foo = n / x;
         - null
 
-get_arg_name:
+getArgName:
     -
         - should return argument "foo"
         - foo
@@ -302,7 +302,7 @@ get_arg_name:
         - "[foo=123]"
 
 
-parse_var:
+parseVar:
     -
         - should return var "foo" with value "{}"
         - var foo = {}
@@ -320,7 +320,7 @@ parse_var:
         - var foo = 123
         - ['foo', '123']
 
-get_function_return_type:
+getFunctionReturnType:
     -
         - should detect type `boolean` because the name starts with `is`
         - [isFoo, null]
@@ -342,7 +342,7 @@ get_function_return_type:
         - [foo, null]
         - false
 
-is_existing_comment:
+isExistingComment:
     -
         - should return true if line begins with "*"
         - "* comment"
@@ -352,7 +352,7 @@ is_existing_comment:
         - "* funcName(arg1, arg2, ...restArg) {}"
         - false
 
-parse_class:
+parseClass:
     -
         - should parse the class name
         - class test {}

--- a/spec/dataset/languages/php.yaml
+++ b/spec/dataset/languages/php.yaml
@@ -1,6 +1,6 @@
 name: PhpParser
 
-parse_function:
+parseFunction:
     -
         - should parse named function
         - function foo() {}
@@ -62,7 +62,7 @@ parse_function:
         - "$foo;\nfunction bar() {}"
         - null
 
-get_arg_type:
+getArgType:
     -
         - should return no type
         - foo
@@ -120,7 +120,7 @@ get_arg_type:
         - foo = n / x;
         - null
 
-get_arg_name:
+getArgName:
     -
         - should return argument "foo"
         - foo
@@ -147,7 +147,7 @@ get_arg_name:
         - foo
 
 
-parse_var:
+parseVar:
     -
         - should return var "foo" with value "{}"
         - var foo = {}
@@ -165,7 +165,7 @@ parse_var:
         - var foo = 123
         - ['foo', '123']
 
-parse_class:
+parseClass:
     -
         - should parse class name
         - class test { $foo; }
@@ -181,7 +181,7 @@ parse:
         - "$foo;\nfunction bar() {}"
         - ['${1:[$foo description]}', '@var ${1:[type]}']
 
-parse_args:
+parseArgs:
     -
         - should parse array bracket syntax
         - function foo($bar = [1, 2, 3]) {}

--- a/spec/dataset/languages/processing.yaml
+++ b/spec/dataset/languages/processing.yaml
@@ -1,6 +1,6 @@
 name: ProcessingParser
 
-parse_function:
+parseFunction:
     -
         - should parse a simple method
         - void foo() {}
@@ -23,7 +23,7 @@ parse_function:
         - ['foo', null, 'char[]', null]
 
 
-get_function_return_type:
+getFunctionReturnType:
     -
         - should return `null` because `void` methods have no return
         - ['fooBar', 'void']

--- a/spec/dataset/languages/rust.yaml
+++ b/spec/dataset/languages/rust.yaml
@@ -1,6 +1,6 @@
 name: RustParser
 
-parse_function:
+parseFunction:
     -
         - should parse simple function
         - fn main() {}
@@ -39,7 +39,7 @@ parse_function:
         - ['is_bar', null]
 
 
-parse_var:
+parseVar:
     -
         - should parse variable declaration
         - let foo;

--- a/spec/dataset/languages/sass.yaml
+++ b/spec/dataset/languages/sass.yaml
@@ -1,6 +1,6 @@
 name: SassParser
 
-parse_function:
+parseFunction:
     -
         - should parse mixin
         - '@mixin foo() {}'
@@ -30,7 +30,7 @@ parse_function:
         - '@mixin foo {}'
         - ['foo', null, null]
 
-get_arg_type:
+getArgType:
     -
         - should return no type
         - $foo
@@ -136,7 +136,7 @@ get_arg_type:
         - "$foo: n / x;"
         - null
 
-get_arg_name:
+getArgName:
     -
         - should return argument "$foo"
         - $foo
@@ -162,7 +162,7 @@ get_arg_name:
       - "@function(invalidValue) {}"
       - null
 
-parse_var:
+parseVar:
     -
         - should return var "foo" with value "()"
         - '$foo: ()'
@@ -176,7 +176,7 @@ parse_var:
         - '$foo: 123'
         - ['$foo', '123']
 
-get_function_return_type:
+getFunctionReturnType:
     -
         - should detect type `boolean` because the name starts with `is`
         - [isFoo, null]


### PR DESCRIPTION
Also contains some slight cleanup that was possible after the change.
See commit messages for details.

I'll do one more pull request after this, with some general cleanup before I start working on the customizability feature (which will probably result in a non backwards compatible version).
It'll also fix all the bugs I can find.

Sorry these pull requests are a bit too general, and not focused on just one change. Just let me know and I'll split these up into multiple ones.
I'm hoping this makes it faster overall, not having to go through ~10 different pull requests.