### PR TITLE
Fix issue #317. PHP arguments with '...'. (the branch is 'master')

### DIFF
--- a/lib/languages/php.js
+++ b/lib/languages/php.js
@@ -77,7 +77,7 @@ PhpParser.prototype.get_arg_type = function(arg) {
 
 PhpParser.prototype.get_arg_name = function(arg) {
     var regex = new RegExp(
-        '(' + this.settings.varIdentifier + ')(?:\\s*=.*)?$'
+        '(([.]{3})?' + this.settings.varIdentifier + ')(?:\\s*=.*)?$'
     );
     var matches = regex.exec(arg);
     return matches[1];


### PR DESCRIPTION
Now the result is this:
/**
     * [test description]
     * @param  [type]   $argument  [description]
     * @param  type     $argument2 [description]
     * @param  ArfFof   $arg3      [description]
     * @param  string   $arg4      [description]
     * @param  array    $Arg5      [description]
     * @param  [type]   $arg6      [description]
     * @param  string   $arg7      [description]
     * @param  int      $arg8      [description]
     * @param  array    $arg9      [description]
     * @param  ArgArray $arg10     [description]
     * @param  [type]   ...$arg11  [description]
     * @return [type]              [description]
     */
    public function test($argument, type $argument2, Arf\Fof $arg3, $arg4 = 'value', $Arg5 = [], $arg6 = null, $arg7 = '', $arg8 = 8, Arg\Array $arg9 = [], Arg\Array $arg10, ...$arg11)