### PR TITLE
Do some basic rust parsing of functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,8 @@ You can access the configuration settings by entering `Docblockr` in atom settin
 
 - `extend_double_slash` *(Boolean)* Whether double-slash comments should be extended. An example of this feature is described above. Default: `true`
 
+- `extend_triple_slash` *(Boolean)* Whether triple-slash comments should be extended. An example of this feature is described above. Default: `true`
+
 - `deep_indent` *(Boolean)* Whether pressing tab at the start of a line in docblock should indent to match the previous line's description field. An example of this feature is described above. Default: `true`
 
 - `notation_map` *(Array)* An array of notation objects. Each notation object must define either a `prefix` OR a `regex` property, and a `type` property.

--- a/lib/docblockr-worker.js
+++ b/lib/docblockr-worker.js
@@ -56,7 +56,9 @@ class DocBlockrAtom {
         // Close block comment
         closeBlock: /^\s*\/\*\s*$/,
         // extend line
-        extendLine: /^\s*(\/\/[/!]?|#)/,
+        extendLine: /^\s*(\/\/|#)/,
+        // extend block
+        extendBlock: /^\s*(\/\/[/!])/,
         // Extend docblock by adding an asterix at start
         extend: /^\s*\*(?:.?|.*(?:[^*][^/]|[^*]\/|\*[^/]))\s*$/
       };
@@ -78,6 +80,14 @@ class DocBlockrAtom {
         this.parseBlockCommand(event);
       } else if ((this.editorSettings.extend_double_slash === true) && (this.validateRequest(event, { preceding: true, precedingRegex: regex.extendLine, scope: 'comment.line' }))) {
         // Extend line comments (// and #)
+        const _regex = /^(\s*[^\sa-z0-9]*\s*).*$/;
+        const editor = event.target.closest('atom-text-editor').getModel();
+        const cursorPosition = editor.getCursorBufferPosition();
+        let lineText = editor.lineTextForBufferRow(cursorPosition.row);
+        lineText = lineText.replace(_regex, '$1');
+        editor.insertText('\n' + lineText);
+      } else if ((this.editorSettings.extend_triple_slash === true) && (this.validateRequest(event, { preceding: true, precedingRegex: regex.extendBlock, scope: 'comment.block' }))) {
+        // Extend block comments (/// and //!)
         const _regex = /^(\s*[^\sa-z0-9]*\s*).*$/;
         const editor = event.target.closest('atom-text-editor').getModel();
         const cursorPosition = editor.getCursorBufferPosition();

--- a/lib/docblockr-worker.js
+++ b/lib/docblockr-worker.js
@@ -58,7 +58,7 @@ class DocBlockrAtom {
         // extend line
         extendLine: /^\s*(\/\/|#)/,
         // extend block
-        extendBlock: /^\s*(\/\/[/!])/,
+        extendBlock: /^\s*(\/\/[/!]?)/,
         // Extend docblock by adding an asterix at start
         extend: /^\s*\*(?:.?|.*(?:[^*][^/]|[^*]\/|\*[^/]))\s*$/
       };

--- a/lib/docblockr-worker.js
+++ b/lib/docblockr-worker.js
@@ -27,7 +27,7 @@ class DocBlockrAtom {
     global.atom.commands.add('atom-workspace', 'docblockr:parse-tab', event => {
       const regex = {
         // Parse Command
-        parse: /^\s*(\/\*([*!])|###\*|\/\/\*)\s*$/,
+        parse: /^\s*(\/\*([*!])|###\*|\/\/\*|\/\/\/)\s*$/,
         // Indent Command
         indent: /^(\s*\*|\/\/\/)\s*$/
       };

--- a/lib/docblockr.js
+++ b/lib/docblockr.js
@@ -11,6 +11,10 @@ module.exports = {
       type: 'boolean',
       default: true
     },
+    extend_triple_slash: {
+      type: 'boolean',
+      default: true
+    },
     indentation_spaces: {
       type: 'number',
       default: 1

--- a/lib/languages/rust.js
+++ b/lib/languages/rust.js
@@ -4,123 +4,124 @@ const xregexp = require('xregexp');
 module.exports = class RustParser extends DocsParser {
   setupSettings () {
     this.settings = {
-        'commentType': 'block',
-        'curlyTypes': false,
-        'typeInfo': false,
-        'typeTag': false,
-        'prefix': '///',
-        'varIdentifier': '[a-zA-Z_][a-zA-Z_0-9]*',
-        'fnIdentifier': '[a-zA-Z_][a-zA-Z_0-9]*',
-        'classIdentifier': '[A-Z_][a-zA-Z0-9]*',
-        'fnOpener': '^\\s*fn',
-        'commentCloser': '///',
-        'bool': 'bool',
-        'function': 'fn'
+      commentType: 'block',
+      curlyTypes: false,
+      typeInfo: false,
+      typeTag: false,
+      prefix: '///',
+      varIdentifier: '[a-zA-Z_][a-zA-Z_0-9]*',
+      fnIdentifier: '[a-zA-Z_][a-zA-Z_0-9]*',
+      classIdentifier: '[A-Z_][a-zA-Z0-9]*',
+      fnOpener: '^\\s*fn',
+      commentCloser: '///',
+      bool: 'bool',
+      function: 'fn'
     };
   }
 
-parseClass (line) {
+  parseClass (line) {
     // preamble looks for #[derive] and or pub if any
     const preamble = '^[\\s*\\n]*(#\\[.+\\])?[\\s\\n]*(\\bpub([(].+[)])?)?';
     const regex = xregexp(
-        preamble + '\\s*(struct|trait|enum)\\s+(?P<name>' + this.settings.classIdentifier + ')'
+      preamble + '\\s*(struct|trait|enum)\\s+(?P<name>' + this.settings.classIdentifier + ')'
     );
 
     const matches = xregexp.exec(line, regex);
     if (matches === null || matches.name === undefined) {
-        return null;
+      return null;
     }
     const name = matches.name;
     return [name];
-}
+  }
 
-parseFunction (line) {
+  parseFunction (line) {
     // TODO: add regexp for closures syntax
 
     // preamble looks for #[derive] and or pub if any
     var preamble = '^[\\s*\\n]*(#\\[.+\\])?[\\s\\n]*(\\bpub([(].+[)])?)?';
 
     var regex = xregexp(
-        preamble +
-        '\\s*fn\\s+(?P<name>' + this.settings.fnIdentifier + ')' +
-        '([<][a-zA-Z, _]+[>])?' + // Type parameters if any
-        '\\s*\\(\\s*(?P<args>.*?)\\)' + // List of parameters
-        '(\\s*[-][>]\\s*(?P<retval>[^{]+))?' + // Return value if any
-        '\\s*[{;]?' // closing brace if any
+      preamble +
+                '\\s*fn\\s+(?P<name>' + this.settings.fnIdentifier + ')' +
+                '([<][a-zA-Z, _]+[>])?' + // Type parameters if any
+                '\\s*\\(\\s*(?P<args>.*?)\\)' + // List of parameters
+                '(\\s*[-][>]\\s*(?P<retval>[^{]+))?' + // Return value if any
+                '\\s*[{;]?' // closing brace if any
     );
 
     const matches = xregexp.exec(line, regex);
     if (matches === null || matches.name === undefined) {
-        return null;
+      return null;
     }
     const name = matches.name;
     const args = (matches.args ? matches.args.trim() : null);
     const retval = (matches.retval ? matches.retval.trim() : null);
     return [name, args, retval];
-};
+  }
 
-parseVar (line) {
+  parseVar (line) {
     // TODO: add support for struct and tuple destructuring
     // TODO: parse type and value
     const preamble = '^[\\s\\n]*(#\\[.+\\])?[\\s\\n]*';
     const regex = xregexp(
-        preamble +
-        '\\s*let\\s+(mut\\s+)?(?P<name>' + this.settings.varIdentifier + ')'
+      preamble +
+                '\\s*let\\s+(mut\\s+)?(?P<name>' + this.settings.varIdentifier + ')'
     );
 
     const matches = xregexp.exec(line, regex);
     if (matches === null || matches.name === undefined) {
-        return null;
+      return null;
     }
 
     const name = matches.name;
     return [name, null, null];
   }
 
-formatFunction (name, args, retval) {
+  formatFunction (name, args, retval) {
     var out = [];
-    var var_count = 1;
-    out.push('${' + var_count + ':short description}');
-    var_count += 1;
+    var varCount = 1;
+    out.push('${' + varCount + ':short description}');
+    varCount += 1;
     out.push('');
-    out.push('${' + var_count + ':long description}');
-    var_count += 1;
+    out.push('${' + varCount + ':long description}');
+    varCount += 1;
 
     if (args) {
-        // console.log(args);
-        var lst_args = args.split(',');
-        lst_args = lst_args.filter(arg => arg.includes(':'));
-        // console.log(lst_args);
-        if (lst_args.length > 0) {
+      // console.log(args);
+      var lstArgs = args.split(',');
+      lstArgs = lstArgs.filter(arg => arg.includes(':'));
+      // console.log(lstArgs);
+      if (lstArgs.length > 0) {
+        out.push('');
+        out.push('# Parameters');
+        lstArgs.forEach(lstArg => {
+          var regex = xregexp('^\\s*(?P<name>' + this.settings.varIdentifier + '):\\s*(?<type>.+)\\s*$');
+          var matches = xregexp.exec(lstArg, regex);
+          if (matches) {
             out.push('');
-            out.push('# Parameters');
-            lst_args.forEach(lst_arg => {
-                var regex = xregexp('^\\s*(?P<name>' + this.settings.varIdentifier + '):\\s*(?<type>.+)\\s*$');
-                var matches = xregexp.exec(lst_arg, regex);
-                if (matches) {
-                    out.push('');
-                    out.push('* `' + matches.name + '` - ${' + var_count + ':' + matches.name + '}');
-                    var_count += 1;
-                }
-            });
-        }
+            out.push('* `' + matches.name + '` - ${' + varCount + ':' + matches.name + '}');
+            varCount += 1;
+          }
+        });
+      }
     }
 
     if (retval) {
-        out.push('');
-        out.push('# Returns');
-        out.push('');
-        out.push('${' + var_count + ':returns description}');
-        var_count += 1;
+      out.push('');
+      out.push('# Returns');
+      out.push('');
+      out.push('${' + varCount + ':returns description}');
+      varCount += 1;
     }
 
     return out;
-};
+  }
 
-formatClass (name) {
+  formatClass (name) {
     return ['${1:describe ' + name + '}'];
-}
+  }
 
-formatVar (name, val, valType) {
+  formatVar (name, val, valType) {
     return ['${1:describe ' + name + '}'];
+  }
 };

--- a/lib/languages/rust.js
+++ b/lib/languages/rust.js
@@ -87,10 +87,10 @@ formatFunction (name, args, retval) {
   var_count += 1;
 
   if (args) {
-    console.log(args);
+    // console.log(args);
     var lst_args = args.split(',');
     lst_args = lst_args.filter(arg => arg.includes(':'));
-    console.log(lst_args);
+    // console.log(lst_args);
     if (lst_args.length > 0) {
       out.push('');
       out.push('# Parameters');

--- a/lib/languages/rust.js
+++ b/lib/languages/rust.js
@@ -20,18 +20,18 @@ module.exports = class RustParser extends DocsParser {
   }
 
 parseClass (line) {
-  // preamble looks for #[derive] and or pub if any
-  const preamble = '^[\\s*\\n]*(#\\[.+\\])?[\\s\\n]*(\\bpub([(].+[)])?)?';
-  const regex = xregexp(
-    preamble + '\\s*(struct|trait|enum)\\s+(?P<name>' + this.settings.classIdentifier + ')'
-  );
+    // preamble looks for #[derive] and or pub if any
+    const preamble = '^[\\s*\\n]*(#\\[.+\\])?[\\s\\n]*(\\bpub([(].+[)])?)?';
+    const regex = xregexp(
+        preamble + '\\s*(struct|trait|enum)\\s+(?P<name>' + this.settings.classIdentifier + ')'
+    );
 
-  var matches = xregexp.exec(line, regex);
-  if(matches === null || matches.name === undefined) {
-      return null;
-  }
-  var name = matches.name;
-  return [name];
+    const matches = xregexp.exec(line, regex);
+    if (matches === null || matches.name === undefined) {
+        return null;
+    }
+    const name = matches.name;
+    return [name];
 }
 
 parseFunction (line) {
@@ -41,17 +41,17 @@ parseFunction (line) {
     var preamble = '^[\\s*\\n]*(#\\[.+\\])?[\\s\\n]*(\\bpub([(].+[)])?)?';
 
     var regex = xregexp(
-      preamble +
-      '\\s*fn\\s+(?P<name>' + this.settings.fnIdentifier + ')' +
-      '([<][a-zA-Z, _]+[>])?' +  // Type parameters if any
-      '\\s*\\(\\s*(?P<args>.*?)\\)' + // List of parameters
-      '(\\s*[-][>]\\s*(?P<retval>[^{]+))?' + // Return value if any
-      '\\s*[{;]?'  // closing brace if any
+        preamble +
+        '\\s*fn\\s+(?P<name>' + this.settings.fnIdentifier + ')' +
+        '([<][a-zA-Z, _]+[>])?' + // Type parameters if any
+        '\\s*\\(\\s*(?P<args>.*?)\\)' + // List of parameters
+        '(\\s*[-][>]\\s*(?P<retval>[^{]+))?' + // Return value if any
+        '\\s*[{;]?' // closing brace if any
     );
 
     const matches = xregexp.exec(line, regex);
     if (matches === null || matches.name === undefined) {
-      return null;
+        return null;
     }
     const name = matches.name;
     const args = (matches.args ? matches.args.trim() : null);
@@ -59,18 +59,18 @@ parseFunction (line) {
     return [name, args, retval];
 };
 
-  parseVar (line) {
+parseVar (line) {
     // TODO: add support for struct and tuple destructuring
     // TODO: parse type and value
     const preamble = '^[\\s*\\n]*(#\\[[^[]+\\])?[\\s*\\n]*';
     const regex = xregexp(
-      preamble +
-      '\\s*let\\s+(mut\\s+)?(?P<name>' + this.settings.varIdentifier + ')'
+        preamble +
+        '\\s*let\\s+(mut\\s+)?(?P<name>' + this.settings.varIdentifier + ')'
     );
 
     const matches = xregexp.exec(line, regex);
     if (matches === null || matches.name === undefined) {
-      return null;
+        return null;
     }
 
     const name = matches.name;
@@ -78,47 +78,47 @@ parseFunction (line) {
   }
 
 formatFunction (name, args, retval) {
-  var out = [];
-  var var_count = 1;
-  out.push('${' + var_count + ':short description}');
-  var_count += 1;
-  out.push('');
-  out.push('${' + var_count + ':long description}');
-  var_count += 1;
-
-  if (args) {
-    // console.log(args);
-    var lst_args = args.split(',');
-    lst_args = lst_args.filter(arg => arg.includes(':'));
-    // console.log(lst_args);
-    if (lst_args.length > 0) {
-      out.push('');
-      out.push('# Parameters');
-      lst_args.forEach(lst_arg => {
-        var regex = xregexp('^\\s*(?P<name>' + this.settings.varIdentifier + '):\\s*(?<type>.+)\\s*$');
-        var matches = xregexp.exec(lst_arg, regex);
-        if (matches) {
-          out.push('');
-        	out.push('* `' + matches.name + '` - ${' + var_count + ':' + matches.name + '}');
-          var_count += 1;
-        }
-      });
-    }
-  }
-
-  if (retval) {
-    out.push('');
-    out.push('# Returns');
-    out.push('');
-    out.push('${' + var_count + ':returns description}');
+    var out = [];
+    var var_count = 1;
+    out.push('${' + var_count + ':short description}');
     var_count += 1;
-  }
+    out.push('');
+    out.push('${' + var_count + ':long description}');
+    var_count += 1;
+
+    if (args) {
+        // console.log(args);
+        var lst_args = args.split(',');
+        lst_args = lst_args.filter(arg => arg.includes(':'));
+        // console.log(lst_args);
+        if (lst_args.length > 0) {
+            out.push('');
+            out.push('# Parameters');
+            lst_args.forEach(lst_arg => {
+                var regex = xregexp('^\\s*(?P<name>' + this.settings.varIdentifier + '):\\s*(?<type>.+)\\s*$');
+                var matches = xregexp.exec(lst_arg, regex);
+                if (matches) {
+                    out.push('');
+                    out.push('* `' + matches.name + '` - ${' + var_count + ':' + matches.name + '}');
+                    var_count += 1;
+                }
+            });
+        }
+    }
+
+    if (retval) {
+        out.push('');
+        out.push('# Returns');
+        out.push('');
+        out.push('${' + var_count + ':returns description}');
+        var_count += 1;
+    }
 
     return out;
 };
 
 formatClass (name) {
-  return ['${1:describe ' + name + '}'];
+    return ['${1:describe ' + name + '}'];
 }
 
 formatVar (name, val, valType) {

--- a/lib/languages/rust.js
+++ b/lib/languages/rust.js
@@ -20,8 +20,9 @@ module.exports = class RustParser extends DocsParser {
   }
 
 parseClass (line) {
-  var preamble = '^[\\s*\\n]*(#\\[[^[]+\\])?[\\s*\\n]*(\\bpub[^ ]*\\b)?';
-  var regex = xregexp(
+  // preamble looks for #[derive] and or pub if any
+  const preamble = '^[\\s*\\n]*(#\\[.+\\])?[\\s\\n]*(\\bpub([(].+[)])?)?';
+  const regex = xregexp(
     preamble + '\\s*(struct|trait|enum)\\s+(?P<name>' + this.settings.classIdentifier + ')'
   );
 
@@ -35,14 +36,17 @@ parseClass (line) {
 
 parseFunction (line) {
     // TODO: add regexp for closures syntax
-    // TODO: parse params
-    var preamble = '^[\\s*\\n]*(#\\[[^[]+\\])?[\\s*\\n]*(\\bpub[^ ]*\\b)?';
+
+    // preamble looks for #[derive] and or pub if any
+    var preamble = '^[\\s*\\n]*(#\\[.+\\])?[\\s\\n]*(\\bpub([(].+[)])?)?';
+
     var regex = xregexp(
       preamble +
       '\\s*fn\\s+(?P<name>' + this.settings.fnIdentifier + ')' +
-      '([<][a-zA-Z, _]+[>])?' +  // List of parameters
-      '\\s*\\(\\s*(?P<args>.*?)\\)' +
-      '(\\s*[-][>]\\s*(?P<retval>[^}]+)\\s*[{;]?)?'
+      '([<][a-zA-Z, _]+[>])?' +  // Type parameters if any
+      '\\s*\\(\\s*(?P<args>.*?)\\)' + // List of parameters
+      '(\\s*[-][>]\\s*(?P<retval>[^{]+))?' + // Return value if any
+      '\\s*[{;]?'  // closing brace if any
     );
 
     const matches = xregexp.exec(line, regex);
@@ -50,9 +54,8 @@ parseFunction (line) {
       return null;
     }
     const name = matches.name;
-    const args = matches.args || null
-    const retval = matches.retval || null
-    console.log(matches);
+    const args = (matches.args ? matches.args.trim() : null);
+    const retval = (matches.retval ? matches.retval.trim() : null);
     return [name, args, retval];
 };
 

--- a/lib/languages/rust.js
+++ b/lib/languages/rust.js
@@ -62,7 +62,7 @@ parseFunction (line) {
 parseVar (line) {
     // TODO: add support for struct and tuple destructuring
     // TODO: parse type and value
-    const preamble = '^[\\s*\\n]*(#\\[[^[]+\\])?[\\s*\\n]*';
+    const preamble = '^[\\s\\n]*(#\\[.+\\])?[\\s\\n]*';
     const regex = xregexp(
         preamble +
         '\\s*let\\s+(mut\\s+)?(?P<name>' + this.settings.varIdentifier + ')'

--- a/lib/languages/rust.js
+++ b/lib/languages/rust.js
@@ -86,7 +86,7 @@ module.exports = class RustParser extends DocsParser {
     out.push('${' + varCount + ':long description}');
     varCount += 1;
 
-    if (args) {
+    if (args && this.editorSettings.param_description) {
       // console.log(args);
       var lstArgs = args.split(',');
       lstArgs = lstArgs.filter(arg => arg.includes(':'));
@@ -106,7 +106,7 @@ module.exports = class RustParser extends DocsParser {
       }
     }
 
-    if (retval) {
+    if (retval && this.editorSettings.return_description) {
       out.push('');
       out.push('# Returns');
       out.push('');

--- a/lib/languages/rust.js
+++ b/lib/languages/rust.js
@@ -11,6 +11,7 @@ module.exports = class RustParser extends DocsParser {
         'prefix': '///',
         'varIdentifier': '[a-zA-Z_][a-zA-Z_0-9]*',
         'fnIdentifier': '[a-zA-Z_][a-zA-Z_0-9]*',
+        'classIdentifier': '[A-Z_][a-zA-Z0-9]*',
         'fnOpener': '^\\s*fn',
         'commentCloser': '///',
         'bool': 'bool',
@@ -18,14 +19,31 @@ module.exports = class RustParser extends DocsParser {
     };
   }
 
-  parseFunction (line) {
+parseClass (line) {
+  var preamble = '^[\\s*\\n]*(#\\[[^[]+\\])?[\\s*\\n]*(\\bpub[^ ]*\\b)?';
+  var regex = xregexp(
+    preamble + '\\s*(struct|trait|enum)\\s+(?P<name>' + this.settings.classIdentifier + ')'
+  );
+
+  var matches = xregexp.exec(line, regex);
+  if(matches === null || matches.name === undefined) {
+      return null;
+  }
+  var name = matches.name;
+  return [name];
+}
+
+parseFunction (line) {
     // TODO: add regexp for closures syntax
     // TODO: parse params
-    const regex = xregexp(
+    var preamble = '^[\\s*\\n]*(#\\[[^[]+\\])?[\\s*\\n]*(\\bpub[^ ]*\\b)?';
+    var regex = xregexp(
+      preamble +
       '\\s*fn\\s+(?P<name>' + this.settings.fnIdentifier + ')' +
+      '([<][a-zA-Z, _]+[>])?' +  // List of parameters
       '\\s*\\(\\s*(?P<args>.*?)\\)' +
       '(\\s*[-][>]\\s*(?P<retval>[^}]+)\\s*[{;]?)?'
-  );
+    );
 
     const matches = xregexp.exec(line, regex);
     if (matches === null || matches.name === undefined) {
@@ -41,7 +59,11 @@ module.exports = class RustParser extends DocsParser {
   parseVar (line) {
     // TODO: add support for struct and tuple destructuring
     // TODO: parse type and value
-    const regex = xregexp('\\s*let\\s+(mut\\s+)?(?P<name>' + this.settings.varIdentifier + ')');
+    const preamble = '^[\\s*\\n]*(#\\[[^[]+\\])?[\\s*\\n]*';
+    const regex = xregexp(
+      preamble +
+      '\\s*let\\s+(mut\\s+)?(?P<name>' + this.settings.varIdentifier + ')'
+    );
 
     const matches = xregexp.exec(line, regex);
     if (matches === null || matches.name === undefined) {
@@ -92,7 +114,10 @@ formatFunction (name, args, retval) {
     return out;
 };
 
-  formatVar (name, val, valType) {
-    return [name];
-  }
+formatClass (name) {
+  return ['${1:describe ' + name + '}'];
+}
+
+formatVar (name, val, valType) {
+    return ['${1:describe ' + name + '}'];
 };

--- a/lib/languages/rust.js
+++ b/lib/languages/rust.js
@@ -4,31 +4,39 @@ const xregexp = require('xregexp');
 module.exports = class RustParser extends DocsParser {
   setupSettings () {
     this.settings = {
-      commentType: 'block',
-      curlyTypes: false,
-      typeInfo: false,
-      typeTag: false,
-      varIdentifier: '[a-zA-Z_][a-zA-Z_0-9]*',
-      fnIdentifier: '[a-zA-Z_][a-zA-Z_0-9]*',
-      fnOpener: '^\\s*fn',
-      commentCloser: ' */',
-      bool: 'bool',
-      function: 'fn'
+        'commentType': 'block',
+        'curlyTypes': false,
+        'typeInfo': false,
+        'typeTag': false,
+        'prefix': '///',
+        'varIdentifier': '[a-zA-Z_][a-zA-Z_0-9]*',
+        'fnIdentifier': '[a-zA-Z_][a-zA-Z_0-9]*',
+        'fnOpener': '^\\s*fn',
+        'commentCloser': '///',
+        'bool': 'bool',
+        'function': 'fn'
     };
   }
 
   parseFunction (line) {
     // TODO: add regexp for closures syntax
     // TODO: parse params
-    const regex = xregexp('\\s*fn\\s+(?P<name>' + this.settings.fnIdentifier + ')');
+    const regex = xregexp(
+      '\\s*fn\\s+(?P<name>' + this.settings.fnIdentifier + ')' +
+      '\\s*\\(\\s*(?P<args>.*?)\\)' +
+      '(\\s*[-][>]\\s*(?P<retval>[^}]+)\\s*[{;]?)?'
+  );
 
     const matches = xregexp.exec(line, regex);
     if (matches === null || matches.name === undefined) {
       return null;
     }
     const name = matches.name;
-    return [name, null];
-  }
+    const args = matches.args || null
+    const retval = matches.retval || null
+    console.log(matches);
+    return [name, args, retval];
+};
 
   parseVar (line) {
     // TODO: add support for struct and tuple destructuring
@@ -44,9 +52,45 @@ module.exports = class RustParser extends DocsParser {
     return [name, null, null];
   }
 
-  formatFunction (name, args) {
-    return [name];
+formatFunction (name, args, retval) {
+  var out = [];
+  var var_count = 1;
+  out.push('${' + var_count + ':short description}');
+  var_count += 1;
+  out.push('');
+  out.push('${' + var_count + ':long description}');
+  var_count += 1;
+
+  if (args) {
+    console.log(args);
+    var lst_args = args.split(',');
+    lst_args = lst_args.filter(arg => arg.includes(':'));
+    console.log(lst_args);
+    if (lst_args.length > 0) {
+      out.push('');
+      out.push('# Parameters');
+      lst_args.forEach(lst_arg => {
+        var regex = xregexp('^\\s*(?P<name>' + this.settings.varIdentifier + '):\\s*(?<type>.+)\\s*$');
+        var matches = xregexp.exec(lst_arg, regex);
+        if (matches) {
+          out.push('');
+        	out.push('* `' + matches.name + '` - ${' + var_count + ':' + matches.name + '}');
+          var_count += 1;
+        }
+      });
+    }
   }
+
+  if (retval) {
+    out.push('');
+    out.push('# Returns');
+    out.push('');
+    out.push('${' + var_count + ':returns description}');
+    var_count += 1;
+  }
+
+    return out;
+};
 
   formatVar (name, val, valType) {
     return [name];

--- a/spec/dataset/languages/rust.yaml
+++ b/spec/dataset/languages/rust.yaml
@@ -50,7 +50,7 @@ parseFunction:
         - 'fn is_bar<T, U>(a: T) -> U'
         - ['is_bar', 'a: T', 'U']
 
-parse_class:
+parseClass:
     -
         - should parse basic struct
         - struct Foo {
@@ -75,7 +75,7 @@ parse_class:
         - should parse basic enum
         - enum Foo {
         - ['Foo']
-parse_var:
+parseVar:
     -
         - should parse variable declaration
         - let foo;

--- a/spec/dataset/languages/rust.yaml
+++ b/spec/dataset/languages/rust.yaml
@@ -4,42 +4,78 @@ parseFunction:
     -
         - should parse simple function
         - fn main() {}
-        - ['main', null]
+        - ['main', null, null]
+    -
+        - should parse simple public function
+        - pub fn main() {}
+        - ['main', null, null]
+    -
+        - should parse simple public crate function
+        - pub(crate) fn main() {}
+        - ['main', null, null]
     -
         - should parse function with return type
         - fn foo() -> i32 {
-        - ['foo', null]
+        - ['foo', null, 'i32']
     -
         - should parse function with params
         - 'fn bar(x: i32, y: &str) {'
-        - ['bar', null]
+        - ['bar', 'x: i32, y: &str', null]
     -
         - should parse function with params and return type
         - 'fn baz(x: i32) -> i32 {'
-        - ['baz', null]
+        - ['baz', 'x: i32', 'i32']
     -
         - should parse function with mutable reference as param
         - 'fn add_one(x: &mut i32) -> i32 {'
-        - ['add_one', null]
+        - ['add_one', 'x: &mut i32', 'i32']
     -
         - should parse function with complex return type
         - 'fn do_something(y: &mut u64) -> (i32, &str) {'
-        - ['do_something', null]
+        - ['do_something', 'y: &mut u64', '(i32, &str)']
     -
         - should parse function in uncommon syntax
         - 'fn foo  ( x  : i32   )  -> i32'
-        - ['foo', null]
+        - ['foo', 'x  : i32', 'i32']
     -
         - should parse method with normal `self` reference and return type
         - fn is_foo(&self) -> bool
-        - ['is_foo', null]
+        - ['is_foo', '&self', 'bool']
     -
         - should parse method with mutable `self` reference and extra param
-        - 'fn is_bar(&self, x: &mut Bar)'
-        - ['is_bar', null]
+        - 'fn is_bar(&mut self, x: &mut Bar)'
+        - ['is_bar', '&mut self, x: &mut Bar', null]
+    -
+        - should parse method with type definition
+        - 'fn is_bar<T, U>(a: T) -> U'
+        - ['is_bar', 'a: T', 'U']
 
-
-parseVar:
+parse_class:
+    -
+        - should parse basic struct
+        - struct Foo {
+        - ['Foo']
+    -
+        - should parse basic public struct
+        - pub struct Foo {
+        - ['Foo']
+    -
+        - should parse basic crate public struct
+        - pub(crate) struct Foo {
+        - ['Foo']
+    -
+        - should parse basic struct with derive
+        - '#[derive(Clone)] pub(crate) struct Foo {'
+        - ['Foo']
+    -
+        - should parse basic trait
+        - trait Foo {
+        - ['Foo']
+    -
+        - should parse basic enum
+        - enum Foo {
+        - ['Foo']
+parse_var:
     -
         - should parse variable declaration
         - let foo;


### PR DESCRIPTION
First off I apologise for my poor javascript. Not my native language.

Here I add a simple extension to add rust parsing of functions and formatting the output.

The formatted output tries to adhere to the format recommended by the [rust book](https://doc.rust-lang.org/rust-by-example/meta/doc.html) and the machine readable [specs](https://deterministic.space/machine-readable-inline-markdown-code-cocumentation.html)

Comments, suggests, outright crying over poor js code blasphemys are expected and encouraged.

Fixes: #331 
Fixes: #347
